### PR TITLE
Fix client crash due to ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
@@ -196,6 +196,8 @@ public class GuiBloodInfuser extends GuiContainer
             if (this.topOut == 38) {
                 for (int index = 0; index < this.cachedEffects.tagCount(); ++index) {
                     final Byte id = this.cachedEffects.getCompoundTagAt(index).getByte("Id");
+                    if (id < 0 || id >= Potion.potionTypes.length)
+                        continue;
                     final Potion potion = Potion.potionTypes[id];
                     if (potion != null) {
                         this.mc.getTextureManager().bindTexture(GuiBloodInfuser.field_147001_a);


### PR DESCRIPTION
We have heavily modded modpack and this exception throws when Seroconverter is used.

```
java.lang.ArrayIndexOutOfBoundsException: -1
	at com.kentington.thaumichorizons.client.gui.GuiBloodInfuser.func_146979_b(GuiBloodInfuser.java:199)
	at net.minecraft.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:119)
	at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1455)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001)
```