### PR TITLE
Reduced portal cooldown

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
@@ -80,10 +80,10 @@ public class BlockPortalTH extends BlockBreakable
     public void onEntityCollidedWithBlock(final World world, final int x, final int y, final int z, final Entity player) {
         if (player.ridingEntity == null && player.riddenByEntity == null && player instanceof EntityPlayerMP) {
             if (player.timeUntilPortal > 0) {
-                player.timeUntilPortal = 100;
+                player.timeUntilPortal = 10;
                 return;
             }
-            player.timeUntilPortal = 100;
+            player.timeUntilPortal = 10;
             int targetX = 0;
             int targetY = 0;
             int targetZ = 0;

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -143,14 +143,14 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                             if (player.ridingEntity == null && player.riddenByEntity == null) {
                                 final MinecraftServer mServer = FMLCommonHandler.instance().getMinecraftServerInstance();
                                 if (player.timeUntilPortal > 0) {
-                                    player.timeUntilPortal = 100;
+                                    player.timeUntilPortal = 10;
                                 }
                                 else if (player.dimension != ThaumicHorizons.dimensionPocketId) {
-                                    player.timeUntilPortal = 100;
+                                    player.timeUntilPortal = 10;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(player, ThaumicHorizons.dimensionPocketId, (Teleporter)new VortexTeleporter(mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId), this.dimensionID));
                                 }
                                 else {
-                                    player.timeUntilPortal = 100;
+                                    player.timeUntilPortal = 10;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(player, this.returnID, (Teleporter)new VortexTeleporter(mServer.worldServerForDimension(this.returnID), this.dimensionID));
                                 }
                             }


### PR DESCRIPTION
This fixes an issue in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7338

The cooldown of the portal resetting is important so you don't get sent back before exiting it, so I've lessened the impact by reducing the cooldown from 5 seconds to 0.5. This means if you walk out of the portal, you can use it by walking back in after 0.5 seconds.