### PR TITLE
Added dim to portal values

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
@@ -94,15 +94,16 @@ public class BlockPortalTH extends BlockBreakable
                 final PocketPlaneData plane = PocketPlaneData.planes.get(planeNum);
                 final int[] portal;
 
+                //Note the order ACBD
                 switch (which) {
                     case 0:
                         portal = plane.portalA;
                         break;
                     case 1:
-                        portal = plane.portalB;
+                        portal = plane.portalC;
                         break;
                     case 2:
-                        portal = plane.portalC;
+                        portal = plane.portalB;
                         break;
                     case 3:
                         portal = plane.portalD;
@@ -117,40 +118,6 @@ public class BlockPortalTH extends BlockBreakable
                 if (portal.length > 3)
                     targetDim = portal[3];
 
-                switch (which) {
-                    case 0: {
-                        targetX = PocketPlaneData.planes.get(planeNum).portalA[0];
-                        targetY = PocketPlaneData.planes.get(planeNum).portalA[1] - 2;
-                        targetZ = PocketPlaneData.planes.get(planeNum).portalA[2];
-                        if (PocketPlaneData.planes.get(planeNum).portalA.length > 3)
-                            targetDim = PocketPlaneData.planes.get(planeNum).portalA[3];
-                        break;
-                    }
-                    case 2: {
-                        targetX = PocketPlaneData.planes.get(planeNum).portalB[0];
-                        targetY = PocketPlaneData.planes.get(planeNum).portalB[1] - 2;
-                        targetZ = PocketPlaneData.planes.get(planeNum).portalB[2];
-                        if (PocketPlaneData.planes.get(planeNum).portalB.length > 3)
-                            targetDim = PocketPlaneData.planes.get(planeNum).portalB[3];
-                        break;
-                    }
-                    case 1: {
-                        targetX = PocketPlaneData.planes.get(planeNum).portalC[0];
-                        targetY = PocketPlaneData.planes.get(planeNum).portalC[1] - 2;
-                        targetZ = PocketPlaneData.planes.get(planeNum).portalC[2];
-                        if (PocketPlaneData.planes.get(planeNum).portalC.length > 3)
-                            targetDim = PocketPlaneData.planes.get(planeNum).portalC[3];
-                        break;
-                    }
-                    case 3: {
-                        targetX = PocketPlaneData.planes.get(planeNum).portalD[0];
-                        targetY = PocketPlaneData.planes.get(planeNum).portalD[1] - 2;
-                        targetZ = PocketPlaneData.planes.get(planeNum).portalD[2];
-                        if (PocketPlaneData.planes.get(planeNum).portalD.length == 4)
-                            targetDim = PocketPlaneData.planes.get(planeNum).portalD[3];
-                        break;
-                    }
-                }
                 final MinecraftServer mServer = FMLCommonHandler.instance().getMinecraftServerInstance();
                 ((EntityPlayerMP)player).mcServer.getConfigurationManager().transferPlayerToDimension((EntityPlayerMP)player, targetDim, (Teleporter)new GatewayTeleporter(mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId), targetX, targetY, targetZ, player.rotationYaw));
             }

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
@@ -91,6 +91,32 @@ public class BlockPortalTH extends BlockBreakable
             if (world.provider.dimensionId == ThaumicHorizons.dimensionPocketId) {
                 final int planeNum = (z + 128) / 256;
                 final int which = world.getBlockMetadata(x, y, z);
+                final PocketPlaneData plane = PocketPlaneData.planes.get(planeNum);
+                final int[] portal;
+
+                switch (which) {
+                    case 0:
+                        portal = plane.portalA;
+                        break;
+                    case 1:
+                        portal = plane.portalB;
+                        break;
+                    case 2:
+                        portal = plane.portalC;
+                        break;
+                    case 3:
+                        portal = plane.portalD;
+                        break;
+                    default:
+                        return;
+                }
+
+                targetX = portal[0];
+                targetY = portal[1] - 2;
+                targetZ = portal[2];
+                if (portal.length > 3)
+                    targetDim = portal[3];
+
                 switch (which) {
                     case 0: {
                         targetX = PocketPlaneData.planes.get(planeNum).portalA[0];

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockPortalTH.java
@@ -87,6 +87,7 @@ public class BlockPortalTH extends BlockBreakable
             int targetX = 0;
             int targetY = 0;
             int targetZ = 0;
+            int targetDim = 0;
             if (world.provider.dimensionId == ThaumicHorizons.dimensionPocketId) {
                 final int planeNum = (z + 128) / 256;
                 final int which = world.getBlockMetadata(x, y, z);
@@ -95,29 +96,37 @@ public class BlockPortalTH extends BlockBreakable
                         targetX = PocketPlaneData.planes.get(planeNum).portalA[0];
                         targetY = PocketPlaneData.planes.get(planeNum).portalA[1] - 2;
                         targetZ = PocketPlaneData.planes.get(planeNum).portalA[2];
+                        if (PocketPlaneData.planes.get(planeNum).portalA.length > 3)
+                            targetDim = PocketPlaneData.planes.get(planeNum).portalA[3];
                         break;
                     }
                     case 2: {
                         targetX = PocketPlaneData.planes.get(planeNum).portalB[0];
                         targetY = PocketPlaneData.planes.get(planeNum).portalB[1] - 2;
                         targetZ = PocketPlaneData.planes.get(planeNum).portalB[2];
+                        if (PocketPlaneData.planes.get(planeNum).portalB.length > 3)
+                            targetDim = PocketPlaneData.planes.get(planeNum).portalB[3];
                         break;
                     }
                     case 1: {
                         targetX = PocketPlaneData.planes.get(planeNum).portalC[0];
                         targetY = PocketPlaneData.planes.get(planeNum).portalC[1] - 2;
                         targetZ = PocketPlaneData.planes.get(planeNum).portalC[2];
+                        if (PocketPlaneData.planes.get(planeNum).portalC.length > 3)
+                            targetDim = PocketPlaneData.planes.get(planeNum).portalC[3];
                         break;
                     }
                     case 3: {
                         targetX = PocketPlaneData.planes.get(planeNum).portalD[0];
                         targetY = PocketPlaneData.planes.get(planeNum).portalD[1] - 2;
                         targetZ = PocketPlaneData.planes.get(planeNum).portalD[2];
+                        if (PocketPlaneData.planes.get(planeNum).portalD.length == 4)
+                            targetDim = PocketPlaneData.planes.get(planeNum).portalD[3];
                         break;
                     }
                 }
                 final MinecraftServer mServer = FMLCommonHandler.instance().getMinecraftServerInstance();
-                ((EntityPlayerMP)player).mcServer.getConfigurationManager().transferPlayerToDimension((EntityPlayerMP)player, 0, (Teleporter)new GatewayTeleporter(mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId), targetX, targetY, targetZ, player.rotationYaw));
+                ((EntityPlayerMP)player).mcServer.getConfigurationManager().transferPlayerToDimension((EntityPlayerMP)player, targetDim, (Teleporter)new GatewayTeleporter(mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId), targetX, targetY, targetZ, player.rotationYaw));
             }
             else {
                 int slotY = y;

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
@@ -102,10 +102,10 @@ public class PocketPlaneData {
             vortex.dimensionID = PocketPlaneData.planes.size();
             vortex.createdDimension = true;
             world.setTileEntity(xCenter, yCenter + 1, zCenter,vortex);
-            data.portalA = new int[3];
-            data.portalB = new int[3];
-            data.portalC = new int[3];
-            data.portalD = new int[3];
+            data.portalA = new int[4];
+            data.portalB = new int[4];
+            data.portalC = new int[4];
+            data.portalD = new int[4];
             PocketPlaneData.planes.add(data);
             PocketPlaneData.positions.put(pocketPlaneMAXID,Vec3.createVectorHelper((double) vortexX, (double) vortexY, (double) vortexZ));
             //System.out.println("Finished with pocket plane generation!");

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSlot.java
@@ -162,24 +162,28 @@ public class TileSlot extends TileThaumcraft
                         PocketPlaneData.planes.get(this.pocketID).portalA[0] = this.xCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalA[1] = this.yCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalA[2] = this.zCoord;
+                        PocketPlaneData.planes.get(this.pocketID).portalA[3] = player.dimension;
                         break;
                     }
                     case 2: {
                         PocketPlaneData.planes.get(this.pocketID).portalB[0] = this.xCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalB[1] = this.yCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalB[2] = this.zCoord;
+                        PocketPlaneData.planes.get(this.pocketID).portalB[3] = player.dimension;
                         break;
                     }
                     case 3: {
                         PocketPlaneData.planes.get(this.pocketID).portalC[0] = this.xCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalC[1] = this.yCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalC[2] = this.zCoord;
+                        PocketPlaneData.planes.get(this.pocketID).portalC[3] = player.dimension;
                         break;
                     }
                     case 4: {
                         PocketPlaneData.planes.get(this.pocketID).portalD[0] = this.xCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalD[1] = this.yCoord;
                         PocketPlaneData.planes.get(this.pocketID).portalD[2] = this.zCoord;
+                        PocketPlaneData.planes.get(this.pocketID).portalD[3] = player.dimension;
                         break;
                     }
                 }


### PR DESCRIPTION
This adds: Dimension is saved for portals, so it will teleport the player back to the correct dim when exiting a pocket plane.

Portals created before this change will continue to function, and will still send the player to the overworld, since no dim value is saved.