### PR TITLE
Fix for very large Ethereal shard nodes

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -53,66 +53,73 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer
             green /= numPoints + 1;
             blue /= numPoints + 1;
         }
-        final Color col2 = new Color(red, green, blue);
-        UtilsFX.bindTexture("textures/models/crystal.png");
-        final Random rand = new Random(tco.getBlockMetadata() + tco.xCoord + tco.yCoord * tco.zCoord);
-        this.drawCrystal(0, (float)x, (float)y, (float)z, tco.rotation, 0.0f, rand, col2.getRGB(), 1.1f);
-        final long nt = System.nanoTime();
-        UtilsFX.bindTexture(TileEtherealShardRender.tx2);
-        final int frames = 32;
-        final int i = (int)((nt / 40000000L + x) % frames);
-        if (tco != null && tco.getAspectsBase() != null && tco.getAspects() != null && tco.getAspectsBase().size() > 0 && tco.getAspects().getAspects()[0] != null && tco.getAspectsBase().getAspects()[0] != null) {
-            final double offset = 6.283185307179586 / tco.getAspectsBase().size();
-            int which = 0;
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glDepthMask(false);
-            for (final Aspect asp2 : tco.getAspectsBase().getAspects()) {
-                if (asp2 == null) {
-                    break;
+
+        try {
+            final Color col2 = new Color(red, green, blue);
+            UtilsFX.bindTexture("textures/models/crystal.png");
+            final Random rand = new Random(tco.getBlockMetadata() + tco.xCoord + tco.yCoord * tco.zCoord);
+            this.drawCrystal(0, (float) x, (float) y, (float) z, tco.rotation, 0.0f, rand, col2.getRGB(), 1.1f);
+            final long nt = System.nanoTime();
+            UtilsFX.bindTexture(TileEtherealShardRender.tx2);
+            final int frames = 32;
+            final int i = (int) ((nt / 40000000L + x) % frames);
+            if (tco != null && tco.getAspectsBase() != null && tco.getAspects() != null && tco.getAspectsBase().size() > 0 && tco.getAspects().getAspects()[0] != null && tco.getAspectsBase().getAspects()[0] != null) {
+                final double offset = 6.283185307179586 / tco.getAspectsBase().size();
+                int which = 0;
+                GL11.glAlphaFunc(516, 0.003921569f);
+                GL11.glDepthMask(false);
+                for (final Aspect asp2 : tco.getAspectsBase().getAspects()) {
+                    if (asp2 == null) {
+                        break;
+                    }
+                    final Color colo = new Color(asp2.getColor());
+                    GL11.glPushMatrix();
+                    GL11.glEnable(3042);
+                    GL11.glBlendFunc(770, 771);
+                    final double radian = Math.toRadians(tco.rotation);
+                    final double dist = 0.4 + 0.1 * Math.cos(radian);
+                    UtilsFX.renderFacingStrip(tco.xCoord + 0.5 + dist * Math.sin(2.0 * radian + offset * which), tco.yCoord + 0.64 + 0.10000000149011612 * Math.sin(Math.toRadians(tco.rotation)), tco.zCoord + 0.5 + dist * Math.cos(2.0 * radian + offset * which), 0.0f, 0.1f + 0.005f * tco.getAspects().getAmount(asp2), 0.9f, frames, 1, (int) tco.rotation % frames, f, colo.getRGB());
+                    GL11.glDisable(3042);
+                    GL11.glPopMatrix();
+                    ++which;
                 }
-                final Color colo = new Color(asp2.getColor());
+                GL11.glDepthMask(true);
+                GL11.glAlphaFunc(516, 0.1f);
+            }
+            if (tco != null && tco.drainEntity != null && tco.drainCollision != null) {
+                final Entity drainEntity = tco.drainEntity;
+                if (drainEntity instanceof EntityPlayer && !((EntityPlayer) drainEntity).isUsingItem()) {
+                    tco.drainEntity = null;
+                    tco.drainCollision = null;
+                    return;
+                }
+                final MovingObjectPosition drainCollision = tco.drainCollision;
                 GL11.glPushMatrix();
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, 771);
-                final double radian = Math.toRadians(tco.rotation);
-                final double dist = 0.4 + 0.1 * Math.cos(radian);
-                UtilsFX.renderFacingStrip(tco.xCoord + 0.5 + dist * Math.sin(2.0 * radian + offset * which), tco.yCoord + 0.64 + 0.10000000149011612 * Math.sin(Math.toRadians(tco.rotation)), tco.zCoord + 0.5 + dist * Math.cos(2.0 * radian + offset * which), 0.0f, 0.1f + 0.005f * tco.getAspects().getAmount(asp2), 0.9f, frames, 1, (int)tco.rotation % frames, f, colo.getRGB());
-                GL11.glDisable(3042);
+                float f2 = 0.0f;
+                final int iiud = ((EntityPlayer) drainEntity).getItemInUseDuration();
+                if (drainEntity instanceof EntityPlayer) {
+                    f2 = MathHelper.sin(iiud / 10.0f) * 10.0f;
+                }
+                final Vec3 vec3 = Vec3.createVectorHelper(-0.1, -0.1, 0.5);
+                vec3.rotateAroundX(-(drainEntity.prevRotationPitch + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * 3.141593f / 180.0f);
+                vec3.rotateAroundY(-(drainEntity.prevRotationYaw + (drainEntity.rotationYaw - drainEntity.prevRotationYaw) * f) * 3.141593f / 180.0f);
+                vec3.rotateAroundY(-f2 * 0.01f);
+                vec3.rotateAroundX(-f2 * 0.015f);
+                final double d3 = drainEntity.prevPosX + (drainEntity.posX - drainEntity.prevPosX) * f + vec3.xCoord;
+                final double d4 = drainEntity.prevPosY + (drainEntity.posY - drainEntity.prevPosY) * f + vec3.yCoord;
+                final double d5 = drainEntity.prevPosZ + (drainEntity.posZ - drainEntity.prevPosZ) * f + vec3.zCoord;
+                final double d6 = (drainEntity == Minecraft.getMinecraft().thePlayer) ? 0.0 : drainEntity.getEyeHeight();
+                UtilsFX.drawFloatyLine(d3, d4 + d6, d5, drainCollision.blockX + 0.5, drainCollision.blockY + 0.5, drainCollision.blockZ + 0.5, f, tco.color.getRGB(), "textures/misc/wispy.png", -0.02f, Math.min(iiud, 10) / 10.0f);
                 GL11.glPopMatrix();
-                ++which;
             }
-            GL11.glDepthMask(true);
+            GL11.glDisable(3042);
             GL11.glAlphaFunc(516, 0.1f);
-        }
-        if (tco != null && tco.drainEntity != null && tco.drainCollision != null) {
-            final Entity drainEntity = tco.drainEntity;
-            if (drainEntity instanceof EntityPlayer && !((EntityPlayer)drainEntity).isUsingItem()) {
-                tco.drainEntity = null;
-                tco.drainCollision = null;
-                return;
-            }
-            final MovingObjectPosition drainCollision = tco.drainCollision;
-            GL11.glPushMatrix();
-            float f2 = 0.0f;
-            final int iiud = ((EntityPlayer)drainEntity).getItemInUseDuration();
-            if (drainEntity instanceof EntityPlayer) {
-                f2 = MathHelper.sin(iiud / 10.0f) * 10.0f;
-            }
-            final Vec3 vec3 = Vec3.createVectorHelper(-0.1, -0.1, 0.5);
-            vec3.rotateAroundX(-(drainEntity.prevRotationPitch + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * 3.141593f / 180.0f);
-            vec3.rotateAroundY(-(drainEntity.prevRotationYaw + (drainEntity.rotationYaw - drainEntity.prevRotationYaw) * f) * 3.141593f / 180.0f);
-            vec3.rotateAroundY(-f2 * 0.01f);
-            vec3.rotateAroundX(-f2 * 0.015f);
-            final double d3 = drainEntity.prevPosX + (drainEntity.posX - drainEntity.prevPosX) * f + vec3.xCoord;
-            final double d4 = drainEntity.prevPosY + (drainEntity.posY - drainEntity.prevPosY) * f + vec3.yCoord;
-            final double d5 = drainEntity.prevPosZ + (drainEntity.posZ - drainEntity.prevPosZ) * f + vec3.zCoord;
-            final double d6 = (drainEntity == Minecraft.getMinecraft().thePlayer) ? 0.0 : drainEntity.getEyeHeight();
-            UtilsFX.drawFloatyLine(d3, d4 + d6, d5, drainCollision.blockX + 0.5, drainCollision.blockY + 0.5, drainCollision.blockZ + 0.5, f, tco.color.getRGB(), "textures/misc/wispy.png", -0.02f, Math.min(iiud, 10) / 10.0f);
             GL11.glPopMatrix();
         }
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
-        GL11.glPopMatrix();
+        catch (Exception e)
+        {
+            System.out.println("Error rendering Ethereal shard");
+        }
     }
     
     private void drawCrystal(final int ori, final float x, final float y, final float z, final float a1, final float a2, final Random rand, final int color, final float size) {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -34,14 +34,14 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer
     public void renderTileEntityAt(final TileEntity te, final double x, final double y, final double z, final float f) {
         GL11.glPushMatrix();
         final TileSyntheticNode tco = (TileSyntheticNode)te;
-        int red = 255;
-        int green = 255;
-        int blue = 255;
-        int numPoints = 0;
-        int numPointsFilled = 0;
+        long red = 255;
+        long green = 255;
+        long blue = 255;
+        long numPoints = 0;
+        long numPointsFilled = 0;
         if (tco != null && tco.getAspectsBase() != null && tco.getAspects() != null && tco.getAspects().size() > 0 && tco.getAspectsBase().size() > 0) {
             for (final Aspect asp : tco.getAspectsBase().getAspects()) {
-                final int amt = tco.getAspectsBase().getAmount(asp);
+                final long amt = tco.getAspectsBase().getAmount(asp);
                 final Color col = new Color(asp.getColor());
                 red += col.getRed() * amt;
                 green += col.getGreen() * amt;
@@ -52,6 +52,9 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer
             red /= numPoints + 1;
             green /= numPoints + 1;
             blue /= numPoints + 1;
+            red = Math.min(255,Math.max(red, 0));
+            green = Math.min(255,Math.max(green, 0));
+            blue = Math.min(255,Math.max(blue, 0));
         }
 
         try {
@@ -118,7 +121,7 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer
         }
         catch (Exception e)
         {
-            System.out.println("Error rendering Ethereal shard");
+            System.out.println(e.getMessage());
         }
     }
     


### PR DESCRIPTION
This is a fix for what Berta24#2939 discovered: If a ethereal shard is very large, it will crash the client due to an overflow in the color calculation. I extended the variables to long, but also made sure the calculated color will always be valid, and added a try-catch to not crash the whole client when the rendereing fails.