### PR TITLE
A fix to the warp tumor.

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -556,9 +556,10 @@ public class EventHandlerEntity
         if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && event.entityLiving.getHealth() - event.ammount <= 0.0f) {
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
+                // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
+               /* Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
                 Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp);
+                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); */
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -556,10 +556,6 @@ public class EventHandlerEntity
         if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && event.entityLiving.getHealth() - event.ammount <= 0.0f) {
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
-                // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); 
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -557,9 +557,9 @@ public class EventHandlerEntity
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
                 // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
-               /* Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); */
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); 
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);


### PR DESCRIPTION
It currently isn't viable in the pack, you get 60+ warp just to temp store 50 warp, and it wasn't ever reduced in price, this fix will make it delete the 50 warp. Which will solve all of the issues it was previously having. it will still be relatively expensive for what it is, but it will give a pre-IV option to perm warp removal if someone is willing to go the 22 researches + revelations deep needed for this.