### PR TITLE
Buff the warp tumor

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -556,9 +556,10 @@ public class EventHandlerEntity
         if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && event.entityLiving.getHealth() - event.ammount <= 0.0f) {
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
+                // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
+               /* Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
                 Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp);
+                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); */
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -555,8 +555,6 @@ public class EventHandlerEntity
         }
         if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && event.entityLiving.getHealth() - event.ammount <= 0.0f) {
             final EntityPlayer player = (EntityPlayer)event.entity;
-            if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
-            }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);
             for (int a = 0; a < 4; ++a) {

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -556,10 +556,6 @@ public class EventHandlerEntity
         if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && event.entityLiving.getHealth() - event.ammount <= 0.0f) {
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
-                // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                // Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); 
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -557,9 +557,9 @@ public class EventHandlerEntity
             final EntityPlayer player = (EntityPlayer)event.entity;
             if (prop.tumorWarpPermanent > 0 || prop.tumorWarp > 0 || prop.tumorWarpTemp > 0) {
                 // these are meant to add the warp pack to the player, I'm turning them off to make the warp tumor viable again.
-               /* Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
-                Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); */
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpPerm(event.entity.getCommandSenderName(), prop.tumorWarpPermanent);
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpSticky(event.entity.getCommandSenderName(), prop.tumorWarp);
+                // Thaumcraft.proxy.getPlayerKnowledge().addWarpTemp(event.entity.getCommandSenderName(), prop.tumorWarpTemp); 
             }
             prop.resetPlayerInfusions();
             final IInventory baubles = BaublesApi.getBaubles(player);


### PR DESCRIPTION
it will remove 50 perm warp instead of the current storage, 50 isn't enough in the current warp meta since we doubled the warp limits, and likewise, the impure tear is horrifically underpowered with it's meager 5 warp removal for the entirety of what it is. 

As such, adding this as a new warp removal mechanic that is hidden deep in research and warp is necessary!