### PR TITLE
Remove unsafe threading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -6,27 +6,28 @@
  */
 
 
-import com.diffplug.blowdryer.Blowdryer
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
+import com.gtnewhorizons.retrofuturagradle.util.Distribution
 import com.matthewprenger.cursegradle.CurseArtifact
 import com.matthewprenger.cursegradle.CurseRelation
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.jetbrains.gradle.ext.*
+import org.gradle.internal.xml.XmlTransformer
+import org.jetbrains.gradle.ext.Application
+import org.jetbrains.gradle.ext.Gradle
 
+import javax.inject.Inject
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
 
         maven {
@@ -47,6 +48,8 @@ buildscript {
             name 'Scala CI dependencies'
             url 'https://repo1.maven.org/maven2/'
         }
+
+        mavenLocal()
     }
 }
 plugins {
@@ -58,22 +61,26 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
-    id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version ,unused, available for addon.gradle
-    id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.palantir.git-version' version '0.13.0' apply false // 0.13.0 is the last jvm8 supporting version
-    id 'de.undercouch.download' version '5.3.0'
+    id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.palantir.git-version' version '3.0.0' apply false
+    id 'de.undercouch.download' version '5.4.0'
     id 'com.github.gmazzo.buildconfig' version '3.1.0' apply false // Unused, available for addon.gradle
-    id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
     throw new GradleException("Settings has been updated, please re-run task.")
 
-if (project.file('.git/HEAD').isFile()) {
+// In submodules, .git is a file pointing to the real git dir
+if (project.file('.git/HEAD').isFile() || project.file('.git').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
 
@@ -122,7 +129,10 @@ propertyDefaultIfUnset("gradleTokenGroupName", "")
 propertyDefaultIfUnset("enableModernJavaSyntax", false) // On by default for new projects only
 propertyDefaultIfUnset("enableGenericInjection", false) // On by default for new projects only
 
-project.extensions.add(Blowdryer, "Blowdryer", Blowdryer) // Make blowdryer available in "apply from:" scripts
+// this is meant to be set using the user wide property file. by default we do nothing.
+propertyDefaultIfUnset("ideaOverrideBuildType", "") // Can be nothing, "gradle" or "idea"
+
+project.extensions.add(com.diffplug.blowdryer.Blowdryer, "Blowdryer", com.diffplug.blowdryer.Blowdryer) // Make blowdryer available in "apply from:" scripts
 if (!disableSpotless) {
     apply plugin: 'com.diffplug.spotless'
     apply from: Blowdryer.file('spotless.gradle')
@@ -143,11 +153,19 @@ java {
         } else {
             languageVersion.set(projectJavaVersion)
         }
-        vendor.set(JvmVendorSpec.ADOPTIUM)
+        vendor.set(JvmVendorSpec.AZUL)
     }
     if (!noPublishedSources) {
         withSourcesJar()
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType(ScalaCompile).configureEach {
+    options.encoding = "UTF-8"
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
@@ -183,14 +201,34 @@ configurations {
         canBeConsumed = false
         canBeResolved = false
     }
+
+    create("devOnlyNonPublishable") {
+        description = "Runtime and compiletime dependencies that are not published alongside the jar (compileOnly + runtimeOnlyNonPublishable)"
+        canBeConsumed = false
+        canBeResolved = false
+    }
+    compileOnly.extendsFrom(devOnlyNonPublishable)
+    runtimeOnlyNonPublishable.extendsFrom(devOnlyNonPublishable)
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
+    repositories {
+        mavenCentral {
+            mavenContent {
+                includeGroup("me.eigenraven.java8unsupported")
+            }
+        }
+    }
+
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
+        // Allow using jdk.unsupported classes like sun.misc.Unsafe in the compiled code, working around JDK-8206937.
+        patchedMinecraft('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')
     }
 
     tasks.withType(JavaCompile).configureEach {
@@ -202,7 +240,7 @@ if (enableModernJavaSyntax.toBoolean()) {
 
         javaCompiler.set(javaToolchains.compilerFor {
             languageVersion.set(JavaLanguageVersion.of(17))
-            vendor.set(JvmVendorSpec.ADOPTIUM)
+            vendor.set(JvmVendorSpec.AZUL)
         })
     }
 }
@@ -234,12 +272,14 @@ if (apiPackage) {
 }
 
 if (accessTransformersFile) {
-    String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
-    if (!getFile(targetFile).exists()) {
-        throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
+    for (atFile in accessTransformersFile.split(",")) {
+        String targetFile = "src/main/resources/META-INF/" + atFile.trim()
+        if (!getFile(targetFile).exists()) {
+            throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
+        }
+        tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(targetFile)
+        tasks.srgifyBinpatchedJar.accessTransformerFiles.from(targetFile)
     }
-    tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(targetFile)
-    tasks.srgifyBinpatchedJar.accessTransformerFiles.from(targetFile)
 } else {
     boolean atsFound = false
     for (File at : sourceSets.getByName("main").resources.files) {
@@ -367,12 +407,14 @@ minecraft {
         injectMissingGenerics.set(true)
     }
 
+    username = developmentEnvironmentUserName.toString()
+
+    lwjgl3Version = "3.3.2"
+
     // Enable assertions in the current mod
     extraRunJvmArguments.add("-ea:${modGroup}")
 
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        extraTweakClasses.add("org.spongepowered.asm.launch.MixinTweaker")
-
         if (usesMixinDebug.toBoolean()) {
             extraRunJvmArguments.addAll([
                 "-Dmixin.debug.countInjections=true",
@@ -398,6 +440,16 @@ configurations.configureEach {
             if (dep.group == "net.industrial-craft" && dep.name == "industrialcraft-2") {
                 // https://www.curseforge.com/minecraft/mc-mods/industrial-craft/files/2353971
                 project.dependencies.reobfJarConfiguration("curse.maven:ic2-242638:2353971")
+            }
+        }
+    }
+    def obfuscationAttr = it.attributes.getAttribute(ObfuscationAttribute.OBFUSCATION_ATTRIBUTE)
+    if (obfuscationAttr != null && obfuscationAttr.name == ObfuscationAttribute.SRG) {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            // Remap CoFH core cursemaven dev jar to the obfuscated version for runObfClient/Server
+            if (details.requested.group == 'curse.maven' && details.requested.name.endsWith('-69162') && details.requested.version == '2388751') {
+                details.useVersion '2388750'
+                details.because 'Pick obfuscated jar'
             }
         }
     }
@@ -430,8 +482,9 @@ repositories.configureEach { repo ->
 apply from: 'repositories.gradle'
 
 configurations {
+    runtimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
+    testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
     for (config in [compileClasspath, runtimeClasspath, testCompileClasspath, testRuntimeClasspath]) {
-        config.extendsFrom(runtimeOnlyNonPublishable)
         if (usesShadowedDependencies.toBoolean()) {
             config.extendsFrom(shadowImplementation)
             // TODO: remove Compile after all uses are refactored to Implementation
@@ -476,12 +529,11 @@ repositories {
         url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         allowInsecureProtocol = true
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        if (usesMixinDebug.toBoolean()) {
-            maven {
-                name = "Fabric Maven"
-                url = "https://maven.fabricmc.net/"
-            }
+    maven {
+        name 'sonatype'
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        content {
+            includeGroup "org.lwjgl"
         }
     }
     if (includeWellKnownRepositories.toBoolean()) {
@@ -515,26 +567,47 @@ repositories {
     }
 }
 
+def mixinProviderGroup = "io.github.legacymoddingmc"
+def mixinProviderModule = "unimixins"
+def mixinProviderVersion = "0.1.7.1"
+def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
+def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
+
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+        annotationProcessor(mixinProviderSpec)
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.10')
+    if (usesMixins.toBoolean()) {
+        implementation(mixinProviderSpec)
+    } else if (forceEnableMixins.toBoolean()) {
+        runtimeOnlyNonPublishable(mixinProviderSpec)
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+            kapt(mixinProviderSpec)
         }
+    }
+}
+
+// Replace old mixin mods with unimixins
+// https://docs.gradle.org/8.0.2/userguide/resolution_rules.html#sec:substitution_with_classifier
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute module('com.gtnewhorizon:gtnhmixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:Mixingasm') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
     }
 }
 
@@ -633,7 +706,156 @@ tasks.named("processResources", ProcessResources).configure {
 
     if (usesMixins.toBoolean()) {
         from refMap
+        dependsOn("compileJava", "compileScala")
     }
+}
+
+ext.java17Toolchain = (JavaToolchainSpec spec) -> {
+    spec.languageVersion.set(JavaLanguageVersion.of(17))
+    spec.vendor.set(JvmVendorSpec.matching("jetbrains"))
+}
+
+ext.java17DependenciesCfg = configurations.create("java17Dependencies") {
+    extendsFrom(configurations.getByName("runtimeClasspath")) // Ensure consistent transitive dependency resolution
+    canBeConsumed = false
+}
+ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies") {
+    canBeConsumed = false
+}
+
+dependencies {
+    def lwjgl3ifyVersion = '1.3.5'
+    def asmVersion = '9.4'
+    if (modId != 'lwjgl3ify') {
+        java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
+    }
+    if (modId != 'hodgepodge') {
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
+    }
+
+    java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
+    java17PatchDependencies("org.ow2.asm:asm:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-commons:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-tree:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-analysis:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-util:${asmVersion}")
+    java17PatchDependencies('org.ow2.asm:asm-deprecated:7.1')
+    java17PatchDependencies("org.apache.commons:commons-lang3:3.12.0")
+    java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}
+}
+
+ext.java17JvmArgs = [
+    // Java 9+ support
+    "--illegal-access=warn",
+    "-Djava.security.manager=allow",
+    "-Dfile.encoding=UTF-8",
+    "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
+    "--add-opens", "java.base/java.net=ALL-UNNAMED",
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+    "--add-opens", "java.base/java.io=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/java.text=ALL-UNNAMED",
+    "--add-opens", "java.base/java.util=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
+    "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+    "--add-modules", "jdk.dynalink",
+    "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
+    "--add-modules", "java.sql.rowset",
+    "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED"
+]
+
+ext.hotswapJvmArgs = [
+    // DCEVM advanced hot reload
+    "-XX:+AllowEnhancedClassRedefinition",
+    "-XX:HotswapAgent=fatjar"
+]
+
+ext.setupHotswapAgentTask = tasks.register("setupHotswapAgent") {
+    group = "GTNH Buildscript"
+    description = "Installs a recent version of HotSwapAgent into the Java 17 JetBrains runtime directory"
+    def hsaUrl = 'https://github.com/HotswapProjects/HotswapAgent/releases/download/1.4.2-SNAPSHOT/hotswap-agent-1.4.2-SNAPSHOT.jar'
+    def targetFolderProvider = javaToolchains.launcherFor(java17Toolchain).map {it.metadata.installationPath.dir("lib/hotswap")}
+    def targetFilename = "hotswap-agent.jar"
+    onlyIf {
+        !targetFolderProvider.get().file(targetFilename).asFile.exists()
+    }
+    doLast {
+        def targetFolder = targetFolderProvider.get()
+        targetFolder.asFile.mkdirs()
+        download.run {
+            src hsaUrl
+            dest targetFolder.file(targetFilename).asFile
+            overwrite false
+            tempAndMove true
+        }
+    }
+}
+
+public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
+    // IntelliJ doesn't seem to allow commandline arguments so we also support an env variable
+    private boolean enableHotswap = Boolean.valueOf(System.getenv("HOTSWAP"));
+
+    @Input
+    public boolean getEnableHotswap() { return enableHotswap }
+    @Option(option = "hotswap", description = "Enables HotSwapAgent for enhanced class reloading under a debugger")
+    public boolean setEnableHotswap(boolean enable) { enableHotswap = enable }
+
+    @Inject
+    public RunHotswappableMinecraftTask(Distribution side, String superTask, org.gradle.api.invocation.Gradle gradle) {
+        super(side, gradle)
+
+        this.lwjglVersion = 3
+        this.javaLauncher = project.javaToolchains.launcherFor(project.java17Toolchain)
+        this.extraJvmArgs.addAll(project.java17JvmArgs)
+        this.extraJvmArgs.addAll(project.provider(() -> enableHotswap ? project.hotswapJvmArgs : []))
+
+        this.classpath(project.java17PatchDependenciesCfg)
+        if (side == Distribution.CLIENT) {
+            this.classpath(project.minecraftTasks.lwjgl3Configuration)
+        }
+        // Use a raw provider instead of map to not create a dependency on the task
+        this.classpath(project.provider(() -> project.tasks.named(superTask, RunMinecraftTask).get().classpath))
+        this.classpath.filter { file ->
+            !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
+        }
+        this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
+    }
+}
+
+def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Distribution.CLIENT, "runClient")
+runClient17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded client using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStart"
+    username = minecraft.username
+    userUUID = minecraft.userUUID
+}
+
+def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Distribution.DEDICATED_SERVER, "runServer")
+runServer17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded server using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStartServer"
+    extraArgs.add("nogui")
 }
 
 def getManifestAttributes() {
@@ -667,11 +889,6 @@ tasks.named("jar", Jar).configure {
 }
 
 if (usesShadowedDependencies.toBoolean()) {
-    tasks.register('relocateShadowJar', ConfigureShadowRelocation) {
-        target = tasks.shadowJar
-        prefix = modGroup + ".shadow"
-        enabled = minimizeShadowedDependencies.toBoolean()
-    }
     tasks.named("shadowJar", ShadowJar).configure {
         manifest {
             attributes(getManifestAttributes())
@@ -686,8 +903,9 @@ if (usesShadowedDependencies.toBoolean()) {
             project.configurations.shadeCompile
         ]
         archiveClassifier.set('dev')
-        if (minimizeShadowedDependencies.toBoolean()) {
-            dependsOn(relocateShadowJar)
+        if (relocateShadowedDependencies.toBoolean()) {
+            relocationPrefix = modGroup + ".shadow"
+            enableRelocation = true
         }
     }
     configurations.runtimeElements.outgoing.artifacts.clear()
@@ -705,7 +923,7 @@ if (usesShadowedDependencies.toBoolean()) {
     javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
         skip()
     }
-    for (runTask in ["runClient", "runServer"]) {
+    for (runTask in ["runClient", "runServer", "runClient17", "runServer17"]) {
         tasks.named(runTask).configure {
             dependsOn("shadowJar")
         }
@@ -743,15 +961,43 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {
+            if (ideaOverrideBuildType != "") {
+                delegateActions {
+                    if ("gradle".equalsIgnoreCase(ideaOverrideBuildType)) {
+                        delegateBuildRunToGradle = true
+                        testRunner = org.jetbrains.gradle.ext.ActionDelegationConfig.TestRunner.GRADLE
+                    } else if ("idea".equalsIgnoreCase(ideaOverrideBuildType)) {
+                        delegateBuildRunToGradle = false
+                        testRunner = org.jetbrains.gradle.ext.ActionDelegationConfig.TestRunner.PLATFORM
+                    } else {
+                        throw GradleScriptException('Accepted value for ideaOverrideBuildType is one of gradle or idea.')
+                    }
+                }
+            }
             runConfigurations {
                 "1. Run Client"(Gradle) {
                     taskNames = ["runClient"]
                 }
                 "2. Run Server"(Gradle) {
                     taskNames = ["runServer"]
+                }
+                "1a. Run Client (Java 17)"(Gradle) {
+                    taskNames = ["runClient17"]
+                }
+                "2a. Run Server (Java 17)"(Gradle) {
+                    taskNames = ["runServer17"]
+                }
+                "1b. Run Client (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runClient17"]
+                    envs = ["HOTSWAP": "true"]
+                }
+                "2b. Run Server (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runServer17"]
+                    envs = ["HOTSWAP": "true"]
                 }
                 "3. Run Obfuscated Client"(Gradle) {
                     taskNames = ["runObfClient"]
@@ -770,7 +1016,7 @@ idea {
                 }
                 "Run Client (IJ Native)"(Application) {
                     mainClass = "GradleStart"
-                    moduleName = project.name + ".main"
+                    moduleName = project.name + ".ideVirtualMain"
                     afterEvaluate {
                         workingDirectory = tasks.runClient.workingDir.absolutePath
                         programParameters = tasks.runClient.calculateArgs(project).collect { '"' + it + '"' }.join(' ')
@@ -781,7 +1027,7 @@ idea {
                 }
                 "Run Server (IJ Native)"(Application) {
                     mainClass = "GradleStartServer"
-                    moduleName = project.name + ".main"
+                    moduleName = project.name + ".ideVirtualMain"
                     afterEvaluate {
                         workingDirectory = tasks.runServer.workingDir.absolutePath
                         programParameters = tasks.runServer.calculateArgs(project).collect { '"' + it + '"' }.join(' ')
@@ -793,9 +1039,55 @@ idea {
             }
             compiler.javac {
                 afterEvaluate {
+                    javacAdditionalOptions = "-encoding utf8"
                     moduleJavacAdditionalOptions = [
                         (project.name + ".main"): tasks.compileJava.options.compilerArgs.collect { '"' + it + '"' }.join(' ')
                     ]
+                }
+            }
+            withIDEADir { File ideaDir ->
+                if (!ideaDir.path.contains(".idea")) {
+                    // If an .ipr file exists, the project root directory is passed here instead of the .idea subdirectory
+                    ideaDir = new File(ideaDir, ".idea")
+                }
+                if (ideaDir.isDirectory()) {
+                    def miscFile = new File(ideaDir, "misc.xml")
+                    if (miscFile.isFile()) {
+                        boolean dirty = false
+                        def miscTransformer = new XmlTransformer()
+                        miscTransformer.addAction { root ->
+                            Node rootNode = root.asNode()
+                            def rootManager = rootNode
+                                .component.find { it.@name == 'ProjectRootManager' }
+                            if (!rootManager) {
+                                rootManager = rootNode.appendNode('component', ['name': 'ProjectRootManager', 'version': '2'])
+                                dirty = true
+                            }
+                            def output = rootManager.output
+                            if (!output) {
+                                output = rootManager.appendNode('output')
+                                dirty = true
+                            }
+                            if (!output.@url) {
+                                // Only modify the output url if it doesn't yet have one, or if the existing one is blank somehow.
+                                // This is a sensible default for most setups
+                                output.@url = 'file://$PROJECT_DIR$/build/ideaBuild'
+                                dirty = true
+                            }
+                        }
+                        def result = miscTransformer.transform(miscFile.text)
+                        if (dirty) {
+                            miscFile.write(result)
+                        }
+                    } else {
+                        miscFile.text = """<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2">
+    <output url="file://\$PROJECT_DIR\$/out" />
+  </component>
+</project>
+"""
+                    }
                 }
             }
         }
@@ -867,7 +1159,7 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
         }
     }
     if (usesMixins.toBoolean()) {
-        addModrinthDep("required", "project", "gtnhmixins")
+        addModrinthDep("required", "project", "unimixins")
     }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)
@@ -911,7 +1203,7 @@ if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null
         }
     }
     if (usesMixins.toBoolean()) {
-        addCurseForgeRelation("requiredDependency", "gtnhmixins")
+        addCurseForgeRelation("requiredDependency", "unimixins")
     }
     tasks.curseforge.dependsOn(build)
     tasks.publish.dependsOn(tasks.curseforge)
@@ -945,9 +1237,20 @@ def addCurseForgeRelation(String type, String name) {
 }
 
 // Updating
+
+def buildscriptGradleVersion = "8.1.1"
+
+tasks.named('wrapper', Wrapper).configure {
+    gradleVersion = buildscriptGradleVersion
+}
+
 tasks.register('updateBuildScript') {
     group = 'GTNH Buildscript'
     description = 'Updates the build script to the latest version'
+
+    if (gradle.gradleVersion != buildscriptGradleVersion && !Boolean.getBoolean('DISABLE_BUILDSCRIPT_GRADLE_UPDATE')) {
+        dependsOn('wrapper')
+    }
 
     doLast {
         if (performBuildScriptUpdate()) return
@@ -961,6 +1264,26 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         performBuildScriptUpdate()
     } else {
         out.style(Style.SuccessHeader).println("Build script update available! Run 'gradle updateBuildScript'")
+        if (gradle.gradleVersion != buildscriptGradleVersion) {
+            out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
+        }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 
@@ -1101,7 +1424,7 @@ static int replaceParams(File file, Map<String, String> params) {
     return 0
 }
 
-// Dependency Deobfuscation
+// Dependency Deobfuscation (Deprecated, use the new RFG API documented in dependencies.gradle)
 
 def deobf(String sourceURL) {
     try {
@@ -1143,11 +1466,7 @@ def deobfMaven(String repoURL, String mavenDep) {
 }
 
 def deobfCurse(String curseDep) {
-    try {
-        return deobfMaven("https://www.cursemaven.com/", "curse.maven:$curseDep")
-    } catch (Exception ignored) {
-        out.style(Style.Failure).println("Failed to get $curseDep from cursemaven.")
-    }
+    return dependencies.rfg.deobf("curse.maven:$curseDep")
 }
 
 // The method above is to be preferred. Use this method if the filename is not at the end of the URL.
@@ -1155,34 +1474,7 @@ def deobf(String sourceURL, String rawFileName) {
     String bon2Version = "2.5.1"
     String fileName = URLDecoder.decode(rawFileName, "UTF-8")
     String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
-    String bon2Dir = "$cacheDir/forge_gradle/deobf"
-    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
     String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
-    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
-
-    if (file(deobfFile).exists()) {
-        return files(deobfFile)
-    }
-
-    String mappingsVer
-    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
-    if (remoteMappings) {
-        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
-        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
-
-        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
-
-        mappingsVer = "snapshot_$id"
-    } else {
-        mappingsVer = "${channel}_$mappingsVersion"
-    }
-
-    download.run {
-        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
-        dest bon2File
-        quiet true
-        overwrite false
-    }
 
     download.run {
         src sourceURL
@@ -1190,50 +1482,8 @@ def deobf(String sourceURL, String rawFileName) {
         quiet true
         overwrite false
     }
-
-    exec {
-        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
-        workingDir bon2Dir
-        standardOutput = new FileOutputStream("${deobfFile}.log")
-    }
-
-    return files(deobfFile)
+    return dependencies.rfg.deobf(files(obfFile))
 }
-
-def zipMappings(String zipPath, String url, String bon2Dir) {
-    File zipFile = new File(zipPath)
-    if (zipFile.exists()) {
-        return
-    }
-
-    String fieldsCache = "$bon2Dir/data/fields.csv"
-    String methodsCache = "$bon2Dir/data/methods.csv"
-
-    download.run {
-        src "${url}fields.csv"
-        dest fieldsCache
-        quiet true
-    }
-    download.run {
-        src "${url}methods.csv"
-        dest methodsCache
-        quiet true
-    }
-
-    zipFile.getParentFile().mkdirs()
-    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
-
-    zos.putNextEntry(new ZipEntry("fields.csv"))
-    Files.copy(Paths.get(fieldsCache), zos)
-    zos.closeEntry()
-
-    zos.putNextEntry(new ZipEntry("methods.csv"))
-    Files.copy(Paths.get(methodsCache), zos)
-    zos.closeEntry()
-
-    zos.close()
-}
-
 // Helper methods
 
 def checkPropertyExists(String propertyName) {

--- a/src/main/java/com/kentington/thaumichorizons/client/ClientProxy.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/ClientProxy.java
@@ -33,14 +33,6 @@ import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 
-import thaumcraft.api.wands.IWandTriggerManager;
-import thaumcraft.client.fx.ParticleEngine;
-import thaumcraft.client.fx.particles.FXBurst;
-import thaumcraft.client.fx.particles.FXSparkle;
-import thaumcraft.client.fx.particles.FXWisp;
-import thaumcraft.client.renderers.item.ItemWandRenderer;
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.client.fx.FXSonic;
 import com.kentington.thaumichorizons.client.gui.GuiBloodInfuser;
 import com.kentington.thaumichorizons.client.gui.GuiCase;
@@ -177,6 +169,13 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
+import thaumcraft.api.wands.IWandTriggerManager;
+import thaumcraft.client.fx.ParticleEngine;
+import thaumcraft.client.fx.particles.FXBurst;
+import thaumcraft.client.fx.particles.FXSparkle;
+import thaumcraft.client.fx.particles.FXWisp;
+import thaumcraft.client.renderers.item.ItemWandRenderer;
+import thaumcraft.common.Thaumcraft;
 
 public class ClientProxy extends CommonProxy {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
@@ -18,15 +18,15 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.container.ContainerBloodInfuser;
+import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.client.fx.ParticleEngine;
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.config.Config;
-
-import com.kentington.thaumichorizons.common.container.ContainerBloodInfuser;
-import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
 
 public class GuiBloodInfuser extends GuiContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiCase.java
@@ -11,12 +11,11 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.container.ContainerCase;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
 
 @SideOnly(Side.CLIENT)
 public class GuiCase extends GuiContainer {

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiFingers.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiFingers.java
@@ -14,17 +14,16 @@ import net.minecraft.util.MathHelper;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.items.wands.ItemWandCasting;
-import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
-
 import com.kentington.thaumichorizons.common.container.ContainerFingers;
 import com.kentington.thaumichorizons.common.container.InventoryFingers;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 
 @SideOnly(Side.CLIENT)
 public class GuiFingers extends GuiContainer {

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInjector.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInjector.java
@@ -11,9 +11,9 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.container.ContainerInjector;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class GuiInjector extends GuiContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInspiratron.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInspiratron.java
@@ -11,10 +11,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.container.ContainerInspiratron;
 import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class GuiInspiratron extends GuiContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulExtractor.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulExtractor.java
@@ -11,10 +11,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.container.ContainerSoulExtractor;
 import com.kentington.thaumichorizons.common.tiles.TileSoulExtractor;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class GuiSoulExtractor extends GuiContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulforge.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulforge.java
@@ -11,13 +11,12 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.container.ContainerSoulforge;
 import com.kentington.thaumichorizons.common.tiles.TileSoulforge;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
 
 @SideOnly(Side.CLIENT)
 public class GuiSoulforge extends GuiContainer {

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVat.java
@@ -12,12 +12,12 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.lib.research.ResearchManager;
-
 import com.kentington.thaumichorizons.common.container.ContainerVat;
 import com.kentington.thaumichorizons.common.lib.EntityInfusionProperties;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
+
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.lib.research.ResearchManager;
 
 public class GuiVat extends GuiContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVisDynamo.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVisDynamo.java
@@ -14,16 +14,15 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.client.fx.ParticleEngine;
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.container.ContainerVisDynamo;
 import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.client.fx.ParticleEngine;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.config.Config;
 
 @SideOnly(Side.CLIENT)
 public class GuiVisDynamo extends GuiContainer {

--- a/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
@@ -33,11 +33,6 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.api.nodes.IRevealer;
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.Thaumcraft;
-import baubles.api.BaublesApi;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityBoatThaumium;
 import com.kentington.thaumichorizons.common.items.lenses.ILens;
@@ -47,11 +42,15 @@ import com.kentington.thaumichorizons.common.lib.THKeyHandler;
 import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
 import com.kentington.thaumichorizons.common.lib.networking.PacketLensChangeToServer;
 
+import baubles.api.BaublesApi;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.nodes.IRevealer;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.Thaumcraft;
 
 public class RenderEventHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockBloodInfuserRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockBloodInfuserRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockBloodInfuserRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockEssentiaDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockEssentiaDynamoRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileEssentiaDynamo;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockEssentiaDynamoRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockInspiratronRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockInspiratronRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockInspiratronRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockJarTHRenderer.java
@@ -13,11 +13,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.blocks.BlockSoulJar;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockJarTHRenderer extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockNodeMonitorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockNodeMonitorRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileNodeMonitor;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockNodeMonitorRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockRecombinatorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockRecombinatorRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileRecombinator;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockRecombinatorRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSlotRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSlotRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSlot;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSlotRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulBeaconRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulBeaconRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulBeacon;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSoulBeaconRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulSieveRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulSieveRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulExtractor;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSoulSieveRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulforgeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulforgeRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulforge;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSoulforgeRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSpikeRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSpikeRenderer.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSpike;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSpikeRenderer extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSyntheticNodeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSyntheticNodeRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockSyntheticNodeRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockTransductionAmplifierRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockTransductionAmplifierRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileTransductionAmplifier;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockTransductionAmplifierRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatInteriorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatInteriorRender.java
@@ -8,10 +8,10 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockVatInteriorRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatMatrixRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatMatrixRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVatMatrix;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockVatMatrixRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatRender.java
@@ -14,6 +14,7 @@ import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.blocks.BlockVat;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 import com.kentington.thaumichorizons.common.tiles.TileVatSlave;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
 public class BlockVatRender implements ISimpleBlockRenderingHandler {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatSolidRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatSolidRender.java
@@ -13,6 +13,7 @@ import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.blocks.BlockVatSolid;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 import com.kentington.thaumichorizons.common.tiles.TileVatSlave;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
 public class BlockVatSolidRender implements ISimpleBlockRenderingHandler {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVisDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVisDynamoRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockVisDynamoRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVortexStabilizerRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVortexStabilizerRender.java
@@ -12,11 +12,11 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.renderers.block.BlockRenderer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVortexStabilizer;
+
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import thaumcraft.client.renderers.block.BlockRenderer;
 
 public class BlockVortexStabilizerRender extends BlockRenderer implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderFamiliar.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderFamiliar.java
@@ -12,9 +12,9 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.util.ResourceLocation;
 
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.common.entities.EntityFamiliar;
+
+import thaumcraft.common.Thaumcraft;
 
 public class RenderFamiliar extends RenderOcelot {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGoldChicken.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGoldChicken.java
@@ -12,9 +12,9 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityChicken;
 import net.minecraft.util.ResourceLocation;
 
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.common.entities.EntityGoldChicken;
+
+import thaumcraft.common.Thaumcraft;
 
 public class RenderGoldChicken extends RenderChicken {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGolemTH.java
@@ -17,13 +17,13 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.client.renderer.model.ModelGolemTH;
+import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
+
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.entity.RenderGolemBase;
 import thaumcraft.client.renderers.models.entities.ModelGolemAccessories;
 import thaumcraft.common.config.ConfigItems;
-
-import com.kentington.thaumichorizons.client.renderer.model.ModelGolemTH;
-import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
 
 public class RenderGolemTH extends RenderGolemBase {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLunarWolf.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLunarWolf.java
@@ -14,10 +14,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.entities.EntityLunarWolf;
+
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.tile.TileNodeRenderer;
-
-import com.kentington.thaumichorizons.common.entities.EntityLunarWolf;
 
 public class RenderLunarWolf extends RenderWolf {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderTaintfeeder.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderTaintfeeder.java
@@ -15,10 +15,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.entities.EntityTaintPig;
+
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.tile.TileNodeRenderer;
-
-import com.kentington.thaumichorizons.common.entities.EntityTaintPig;
 
 public class RenderTaintfeeder extends RenderPig {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderWizardCow.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderWizardCow.java
@@ -16,14 +16,14 @@ import net.minecraft.util.MathHelper;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.entities.EntityWizardCow;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.api.nodes.NodeType;
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.tile.TileNodeRenderer;
-
-import com.kentington.thaumichorizons.common.entities.EntityWizardCow;
 
 public class RenderWizardCow extends RenderCow {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemInjectorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemInjectorRender.java
@@ -14,9 +14,9 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelInjector;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class ItemInjectorRender implements IItemRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemSyringeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemSyringeRender.java
@@ -12,13 +12,13 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelSyringe;
 import com.kentington.thaumichorizons.common.items.ItemSyringeBlood;
 import com.kentington.thaumichorizons.common.items.ItemSyringeBloodSample;
 import com.kentington.thaumichorizons.common.items.ItemSyringeEmpty;
 import com.kentington.thaumichorizons.common.items.ItemSyringeInjection;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class ItemSyringeRender implements IItemRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/ItemJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/ItemJarTHRenderer.java
@@ -18,11 +18,11 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.config.ConfigBlocks;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulJar;
+
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.config.ConfigBlocks;
 
 public class ItemJarTHRenderer implements IItemRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileBloodInfuserRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileBloodInfuserRender.java
@@ -10,12 +10,12 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelBloodInfuser;
 import com.kentington.thaumichorizons.client.renderer.model.ModelSyringe;
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileBloodInfuserRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEssentiaDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEssentiaDynamoRender.java
@@ -14,12 +14,12 @@ import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.fx.ParticleEngine;
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.fx.FXEssentiaTrail;
 import com.kentington.thaumichorizons.client.renderer.model.ModelQuarterBlock;
 import com.kentington.thaumichorizons.common.tiles.TileEssentiaDynamo;
+
+import thaumcraft.client.fx.ParticleEngine;
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileEssentiaDynamoRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -19,11 +19,11 @@ import net.minecraft.util.Vec3;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.models.ModelCrystal;
-
-import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
 
 public class TileEtherealShardRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileInspiratronRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileInspiratronRender.java
@@ -11,12 +11,12 @@ import net.minecraft.util.MathHelper;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.client.renderer.model.ModelInspiratron;
+import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
+
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.client.renderers.models.ModelBrain;
 import thaumcraft.client.renderers.models.ModelJar;
-
-import com.kentington.thaumichorizons.client.renderer.model.ModelInspiratron;
-import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
 
 public class TileInspiratronRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileJarTHRenderer.java
@@ -11,13 +11,12 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.client.renderers.models.ModelJar;
-
 import com.kentington.thaumichorizons.common.tiles.TileSoulJar;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.client.renderers.models.ModelJar;
 
 @SideOnly(Side.CLIENT)
 public class TileJarTHRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileNodeMonitorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileNodeMonitorRender.java
@@ -12,9 +12,9 @@ import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TileNodeMonitor;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileNodeMonitorRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TilePortalTHRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TilePortalTHRender.java
@@ -15,9 +15,9 @@ import net.minecraft.util.Vec3;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TilePortalTH;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TilePortalTHRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileRecombinatorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileRecombinatorRender.java
@@ -11,15 +11,14 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.tiles.TileNode;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelRecombinator;
 import com.kentington.thaumichorizons.common.tiles.TileRecombinator;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.tiles.TileNode;
 
 @SideOnly(Side.CLIENT)
 public class TileRecombinatorRender extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSlotRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSlotRender.java
@@ -9,13 +9,12 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelReceptacle;
 import com.kentington.thaumichorizons.common.tiles.TileSlot;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
 
 @SideOnly(Side.CLIENT)
 public class TileSlotRender extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulBeaconRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulBeaconRender.java
@@ -13,10 +13,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelSoulBeacon;
 import com.kentington.thaumichorizons.common.tiles.TileSoulBeacon;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileSoulBeaconRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulSieveRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulSieveRender.java
@@ -9,10 +9,10 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelSoulSieve;
 import com.kentington.thaumichorizons.common.tiles.TileSoulExtractor;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileSoulSieveRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulforgeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulforgeRender.java
@@ -9,11 +9,11 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.client.renderers.models.ModelBrain;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelSoulforge;
 import com.kentington.thaumichorizons.common.tiles.TileSoulforge;
+
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.client.renderers.models.ModelBrain;
 
 public class TileSoulforgeRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSpikeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSpikeRender.java
@@ -12,9 +12,9 @@ import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TileSpike;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileSpikeRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileTransductionAmplifierRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileTransductionAmplifierRender.java
@@ -16,12 +16,11 @@ import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TileTransductionAmplifier;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
 
 @SideOnly(Side.CLIENT)
 public class TileTransductionAmplifierRender extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatMatrixRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatMatrixRender.java
@@ -15,16 +15,15 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-import thaumcraft.client.renderers.models.ModelCube;
-import thaumcraft.codechicken.lib.math.MathHelper;
-
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 import com.kentington.thaumichorizons.common.tiles.TileVatMatrix;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.client.renderers.models.ModelCube;
+import thaumcraft.codechicken.lib.math.MathHelper;
 
 @SideOnly(Side.CLIENT)
 public class TileVatMatrixRender extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatRender.java
@@ -9,9 +9,9 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelVat;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileVatRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatSlaveRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatSlaveRender.java
@@ -15,9 +15,9 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TileVat;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileVatSlaveRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVisDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVisDynamoRender.java
@@ -18,10 +18,10 @@ import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelQuarterBlock;
 import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileVisDynamoRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -17,15 +17,14 @@ import net.minecraft.util.Vec3;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.client.lib.QuadHelper;
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.common.tiles.TileVortex;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.client.lib.QuadHelper;
+import thaumcraft.client.lib.UtilsFX;
 
 @SideOnly(Side.CLIENT)
 public class TileVortexRender extends TileEntitySpecialRenderer {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexStabilizerRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexStabilizerRender.java
@@ -9,10 +9,10 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import thaumcraft.client.lib.UtilsFX;
-
 import com.kentington.thaumichorizons.client.renderer.model.ModelVortexAttenuator;
 import com.kentington.thaumichorizons.common.tiles.TileVortexStabilizer;
+
+import thaumcraft.client.lib.UtilsFX;
 
 public class TileVortexStabilizerRender extends TileEntitySpecialRenderer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/CommonProxy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/CommonProxy.java
@@ -13,8 +13,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.Packet;
 import net.minecraft.world.World;
 
-import thaumcraft.api.wands.IWandTriggerManager;
-
 import com.kentington.thaumichorizons.common.container.ContainerBloodInfuser;
 import com.kentington.thaumichorizons.common.container.ContainerCase;
 import com.kentington.thaumichorizons.common.container.ContainerFingers;
@@ -34,6 +32,7 @@ import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.IGuiHandler;
+import thaumcraft.api.wands.IWandTriggerManager;
 
 public class CommonProxy implements IGuiHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/ThaumicHorizons.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/ThaumicHorizons.java
@@ -57,28 +57,6 @@ import net.minecraftforge.oredict.ShapelessOreRecipe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.ThaumcraftApi.EntityTagsNBT;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.crafting.CrucibleRecipe;
-import thaumcraft.api.crafting.InfusionRecipe;
-import thaumcraft.api.crafting.ShapedArcaneRecipe;
-import thaumcraft.api.crafting.ShapelessArcaneRecipe;
-import thaumcraft.api.entities.ITaintedMob;
-import thaumcraft.api.research.ResearchCategories;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
-import thaumcraft.api.wands.WandCap;
-import thaumcraft.api.wands.WandRod;
-import thaumcraft.api.wands.WandTriggerRegistry;
-import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.config.ConfigResearch;
-import thaumcraft.common.entities.monster.EntityPech;
-import thaumcraft.common.entities.monster.EntityWisp;
-import thaumcraft.common.lib.utils.Utils;
-
 import com.kentington.thaumichorizons.client.lib.RenderEventHandler;
 import com.kentington.thaumichorizons.common.blocks.BlockAlchemite;
 import com.kentington.thaumichorizons.common.blocks.BlockBloodInfuser;
@@ -253,6 +231,27 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.ThaumcraftApi.EntityTagsNBT;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
+import thaumcraft.api.crafting.ShapelessArcaneRecipe;
+import thaumcraft.api.entities.ITaintedMob;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
+import thaumcraft.api.wands.WandCap;
+import thaumcraft.api.wands.WandRod;
+import thaumcraft.api.wands.WandTriggerRegistry;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.config.ConfigResearch;
+import thaumcraft.common.entities.monster.EntityPech;
+import thaumcraft.common.entities.monster.EntityWisp;
+import thaumcraft.common.lib.utils.Utils;
 
 @Mod(
         modid = ThaumicHorizons.MODID,

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockBrain.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockBrain.java
@@ -9,10 +9,10 @@ import java.util.Random;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import thaumcraft.common.config.Config;
 import thaumcraft.common.config.ConfigItems;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 public class BlockBrain extends Block {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockCloud.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockCloud.java
@@ -23,17 +23,16 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.damagesource.DamageSourceThaumcraft;
-import thaumcraft.common.items.wands.ItemWandCasting;
-import thaumcraft.common.lib.research.ResearchManager;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
 import com.kentington.thaumichorizons.common.tiles.TileCloud;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.damagesource.DamageSourceThaumcraft;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.lib.research.ResearchManager;
 
 public class BlockCloud extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockEyes.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockEyes.java
@@ -10,9 +10,9 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import thaumcraft.common.config.Config;
 
 public class BlockEyes extends Block {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockFlesh.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockFlesh.java
@@ -10,9 +10,9 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import thaumcraft.common.config.Config;
 
 public class BlockFlesh extends Block {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
@@ -16,13 +16,12 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import thaumcraft.common.config.ConfigBlocks;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSlot;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.config.ConfigBlocks;
 
 public class BlockGatewayPortal extends Block {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockLight.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockLight.java
@@ -17,13 +17,12 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileLight;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.config.Config;
 
 public class BlockLight extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockNodeMonitor.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockNodeMonitor.java
@@ -13,13 +13,12 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import thaumcraft.api.nodes.INode;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileNodeMonitor;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.nodes.INode;
 
 public class BlockNodeMonitor extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
@@ -15,10 +15,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import thaumcraft.common.items.wands.ItemWandCasting;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSlot;
+
+import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class BlockSlot extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
@@ -16,16 +16,15 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.items.ItemWispEssence;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.items.ItemWispEssence;
 
 public class BlockSyntheticNode extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockTransductionAmplifier.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockTransductionAmplifier.java
@@ -14,13 +14,12 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import thaumcraft.common.tiles.TileNodeEnergized;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileTransductionAmplifier;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.tiles.TileNodeEnergized;
 
 public class BlockTransductionAmplifier extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVat.java
@@ -13,8 +13,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import thaumcraft.api.TileThaumcraft;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 import com.kentington.thaumichorizons.common.tiles.TileVatConnector;
@@ -22,6 +20,7 @@ import com.kentington.thaumichorizons.common.tiles.TileVatSlave;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
 
 public class BlockVat extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVisDynamo.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVisDynamo.java
@@ -13,13 +13,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import thaumcraft.common.items.wands.ItemWandCasting;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class BlockVisDynamo extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVoid.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVoid.java
@@ -7,9 +7,9 @@ package com.kentington.thaumichorizons.common.blocks;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import thaumcraft.common.config.Config;
 
 public class BlockVoid extends Block {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockVortex.java
@@ -23,15 +23,14 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVortex;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.config.Config;
 
 public class BlockVortex extends BlockContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerBloodInfuser.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerBloodInfuser.java
@@ -12,15 +12,14 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.container.SlotOutput;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.container.SlotOutput;
 
 public class ContainerBloodInfuser extends Container {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
@@ -12,10 +12,10 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import thaumcraft.common.container.SlotLimitedByClass;
-
 import com.kentington.thaumichorizons.common.items.lenses.ILens;
 import com.kentington.thaumichorizons.common.items.lenses.ItemLensCase;
+
+import thaumcraft.common.container.SlotLimitedByClass;
 
 public class ContainerCase extends Container {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerInspiratron.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerInspiratron.java
@@ -13,12 +13,11 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import thaumcraft.common.config.ConfigItems;
-
 import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.config.ConfigItems;
 
 public class ContainerInspiratron extends Container {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerVat.java
@@ -11,13 +11,12 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import thaumcraft.common.lib.research.ResearchManager;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.lib.research.ResearchManager;
 
 public class ContainerVat extends Container {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityEndersteed.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityEndersteed.java
@@ -18,6 +18,7 @@ import net.minecraftforge.event.entity.living.EnderTeleportEvent;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+
 import cpw.mods.fml.common.eventhandler.Event;
 
 public class EntityEndersteed extends EntityHorse {

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
@@ -13,12 +13,12 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import baubles.api.BaublesApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.baubles.ItemAmuletVis;
 import thaumcraft.common.items.wands.ItemWandCasting;
-import baubles.api.BaublesApi;
 
 public class EntityFamiliar extends EntityOcelot {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -27,18 +27,6 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.entities.ai.combat.AIAvoidCreeperSwell;
-import thaumcraft.common.entities.ai.combat.AIGolemAttackOnCollide;
-import thaumcraft.common.entities.ai.combat.AIHurtByTarget;
-import thaumcraft.common.entities.ai.combat.AINearestAttackableTarget;
-import thaumcraft.common.entities.ai.misc.AIOpenDoor;
-import thaumcraft.common.entities.golems.EntityGolemBase;
-import thaumcraft.common.entities.golems.EnumGolemType;
-import thaumcraft.common.entities.monster.EntityEldritchGuardian;
-
 import com.kentington.thaumichorizons.client.lib.GolemTHTexture;
 import com.kentington.thaumichorizons.common.entities.ai.EntityAIFollowPlayer;
 import com.kentington.thaumichorizons.common.lib.networking.PacketFXBlocksplosion;
@@ -50,6 +38,17 @@ import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.entities.ai.combat.AIAvoidCreeperSwell;
+import thaumcraft.common.entities.ai.combat.AIGolemAttackOnCollide;
+import thaumcraft.common.entities.ai.combat.AIHurtByTarget;
+import thaumcraft.common.entities.ai.combat.AINearestAttackableTarget;
+import thaumcraft.common.entities.ai.misc.AIOpenDoor;
+import thaumcraft.common.entities.golems.EntityGolemBase;
+import thaumcraft.common.entities.golems.EnumGolemType;
+import thaumcraft.common.entities.monster.EntityEldritchGuardian;
 
 public class EntityGolemTH extends EntityGolemBase {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityLunarWolf.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityLunarWolf.java
@@ -12,12 +12,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
+import baubles.api.BaublesApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.baubles.ItemAmuletVis;
 import thaumcraft.common.items.wands.ItemWandCasting;
-import baubles.api.BaublesApi;
 
 public class EntityLunarWolf extends EntityWolf {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNetherHound.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNetherHound.java
@@ -9,9 +9,9 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.world.World;
 
-import thaumcraft.common.entities.projectile.EntityEmber;
-
 import com.kentington.thaumichorizons.common.items.ItemFocusContainment;
+
+import thaumcraft.common.entities.projectile.EntityEmber;
 
 public class EntityNetherHound extends EntityWolf {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNightmare.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNightmare.java
@@ -22,6 +22,7 @@ import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.lib.NightmareTeleporter;
 import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
 import com.kentington.thaumichorizons.common.lib.networking.PacketMountNightmare;
+
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class EntityNightmare extends EntityEndersteed {

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityOrePig.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityOrePig.java
@@ -12,10 +12,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.entities.ai.EntityAIEatStone;
+
 import thaumcraft.common.config.Config;
 import thaumcraft.common.config.ConfigItems;
-
-import com.kentington.thaumichorizons.common.entities.ai.EntityAIEatStone;
 
 public class EntityOrePig extends EntityPig {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityTaintPig.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityTaintPig.java
@@ -9,9 +9,9 @@ import net.minecraft.entity.passive.EntityPig;
 import net.minecraft.potion.Potion;
 import net.minecraft.world.World;
 
-import thaumcraft.common.config.Config;
-
 import com.kentington.thaumichorizons.common.entities.ai.EntityAIEatTaint;
+
+import thaumcraft.common.config.Config;
 
 public class EntityTaintPig extends EntityPig {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityWizardCow.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityWizardCow.java
@@ -12,6 +12,12 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.lib.networking.PacketGetCowData;
+import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
+import io.netty.buffer.ByteBuf;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.nodes.NodeModifier;
@@ -20,13 +26,6 @@ import thaumcraft.common.blocks.ItemJarFilled;
 import thaumcraft.common.blocks.ItemJarNode;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.config.ConfigItems;
-
-import com.kentington.thaumichorizons.common.lib.networking.PacketGetCowData;
-import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
-
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
-import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
-import io.netty.buffer.ByteBuf;
 
 public class EntityWizardCow extends EntityCow implements IEntityAdditionalSpawnData {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/ai/EntityAIEatTaint.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/ai/EntityAIEatTaint.java
@@ -10,11 +10,11 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.biome.BiomeGenBase;
 
-import thaumcraft.common.config.Config;
-import thaumcraft.common.lib.utils.Utils;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityTaintPig;
+
+import thaumcraft.common.config.Config;
+import thaumcraft.common.lib.utils.Utils;
 
 public class EntityAIEatTaint extends EntityAIBase {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemAmuletMirror.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemAmuletMirror.java
@@ -25,16 +25,15 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.IRunicArmor;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.tiles.TileMirror;
-import baubles.api.BaubleType;
-import baubles.api.IBauble;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemAmuletMirror extends Item implements IBauble, IRunicArmor {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusAnimation.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusAnimation.java
@@ -22,18 +22,17 @@ import net.minecraft.world.WorldSettings;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.world.BlockEvent;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.items.wands.ItemWandCasting;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusAnimation extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusCompound.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusCompound.java
@@ -17,6 +17,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.nodes.INode;
@@ -26,11 +30,6 @@ import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.lib.utils.BlockUtils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusCompound extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusContainment.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusContainment.java
@@ -30,6 +30,15 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntitySoul;
+import com.kentington.thaumichorizons.common.lib.networking.PacketFXContainment;
+import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.FocusUpgradeType;
@@ -40,16 +49,6 @@ import thaumcraft.common.entities.golems.EntityGolemBase;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.utils.BlockUtils;
 import thaumcraft.common.lib.utils.InventoryUtils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntitySoul;
-import com.kentington.thaumichorizons.common.lib.networking.PacketFXContainment;
-import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
-
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusContainment extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusDisintegration.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusDisintegration.java
@@ -30,6 +30,11 @@ import net.minecraft.world.WorldSettings;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.world.BlockEvent;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -42,12 +47,6 @@ import thaumcraft.common.items.ItemCrystalEssence;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 import thaumcraft.common.lib.utils.BlockUtils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusDisintegration extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusIllumination.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusIllumination.java
@@ -17,16 +17,15 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.items.wands.ItemWandCasting;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusIllumination extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusLiquefaction.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemFocusLiquefaction.java
@@ -33,6 +33,10 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.world.BlockEvent;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -42,11 +46,6 @@ import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.utils.BlockUtils;
 import thaumcraft.common.lib.utils.Utils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFocusLiquefaction extends ItemFocusBasic {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemGolemBellTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemGolemBellTH.java
@@ -21,17 +21,16 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.util.IIcon;
 
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.entities.golems.EntityGolemBase;
-import thaumcraft.common.entities.golems.EntityTravelingTrunk;
-import thaumcraft.common.entities.golems.ItemGolemBell;
-import thaumcraft.common.entities.golems.Marker;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.entities.golems.EntityGolemBase;
+import thaumcraft.common.entities.golems.EntityTravelingTrunk;
+import thaumcraft.common.entities.golems.ItemGolemBell;
+import thaumcraft.common.entities.golems.Marker;
 
 public class ItemGolemBellTH extends ItemGolemBell {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemGolemPlacer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemGolemPlacer.java
@@ -18,13 +18,12 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import thaumcraft.codechicken.lib.math.MathHelper;
-import thaumcraft.common.entities.golems.ItemGolemBell;
-
 import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.codechicken.lib.math.MathHelper;
+import thaumcraft.common.entities.golems.ItemGolemBell;
 
 public class ItemGolemPlacer extends thaumcraft.common.entities.golems.ItemGolemPlacer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemInfusionCheat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemInfusionCheat.java
@@ -25,9 +25,6 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.entities.golems.EntityGolemBase;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
@@ -36,6 +33,8 @@ import com.kentington.thaumichorizons.common.lib.EntityInfusionProperties;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.entities.golems.EntityGolemBase;
 
 public class ItemInfusionCheat extends Item {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemInfusionSelfCheat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemInfusionSelfCheat.java
@@ -16,14 +16,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.lib.EntityInfusionProperties;
 import com.kentington.thaumichorizons.common.lib.SelfInfusionRecipe;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.Thaumcraft;
 
 public class ItemInfusionSelfCheat extends Item {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemInjector.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemInjector.java
@@ -21,14 +21,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import thaumcraft.api.IRepairable;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityBlastPhial;
 import com.kentington.thaumichorizons.common.entities.EntitySyringe;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.IRepairable;
 
 public class ItemInjector extends ItemBow implements IRepairable {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemNodeCheat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemNodeCheat.java
@@ -14,14 +14,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.tiles.TileNode;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVortex;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.tiles.TileNode;
 
 public class ItemNodeCheat extends Item {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeBloodSample.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeBloodSample.java
@@ -16,14 +16,13 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.Thaumcraft;
 
 public class ItemSyringeBloodSample extends Item {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemWandCastingDisposable.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemWandCastingDisposable.java
@@ -10,14 +10,13 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.common.items.wands.ItemWandCasting;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class ItemWandCastingDisposable extends ItemWandCasting {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/WandManagerTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/WandManagerTH.java
@@ -10,14 +10,14 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.IWandTriggerManager;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.research.ResearchManager;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 public class WandManagerTH implements IWandTriggerManager {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensCase.java
@@ -19,11 +19,10 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import baubles.api.BaubleType;
-import baubles.api.IBauble;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
@@ -26,6 +26,11 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -40,12 +45,6 @@ import thaumcraft.common.lib.network.playerdata.PacketScannedToServer;
 import thaumcraft.common.lib.research.ScanManager;
 import thaumcraft.common.lib.utils.BlockUtils;
 import thaumcraft.common.lib.utils.EntityUtils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemLensOrderEntropy extends Item implements ILens {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/LensManager.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/LensManager.java
@@ -20,10 +20,10 @@ import net.minecraft.nbt.NBTTagString;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import thaumcraft.api.nodes.IRevealer;
-import baubles.api.BaublesApi;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import baubles.api.BaublesApi;
+import thaumcraft.api.nodes.IRevealer;
 
 public class LensManager {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/BiomeGenPocket.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/BiomeGenPocket.java
@@ -9,9 +9,9 @@ import java.util.Random;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 
-import thaumcraft.common.config.ConfigBlocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.common.config.ConfigBlocks;
 
 public class BiomeGenPocket extends BiomeGenBase {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EntityInfusionProperties.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EntityInfusionProperties.java
@@ -12,9 +12,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IExtendedEntityProperties;
 
-import thaumcraft.api.aspects.AspectList;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import thaumcraft.api.aspects.AspectList;
 
 public class EntityInfusionProperties implements IExtendedEntityProperties {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/EventHandlerEntity.java
@@ -48,19 +48,6 @@ import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.damagesource.DamageSourceThaumcraft;
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.config.Config;
-import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.entities.EntityAspectOrb;
-import thaumcraft.common.entities.EntityFollowingItem;
-import thaumcraft.common.items.relics.ItemHandMirror;
-import thaumcraft.common.lib.network.fx.PacketFXShield;
-import thaumcraft.common.lib.utils.EntityUtils;
-import baubles.api.BaublesApi;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
 import com.kentington.thaumichorizons.common.entities.EntityMeatSlime;
@@ -83,12 +70,24 @@ import com.kentington.thaumichorizons.common.lib.networking.PacketPlayerInfusion
 import com.kentington.thaumichorizons.common.tiles.TileSoulBeacon;
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 
+import baubles.api.BaublesApi;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.damagesource.DamageSourceThaumcraft;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.config.Config;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.entities.EntityAspectOrb;
+import thaumcraft.common.entities.EntityFollowingItem;
+import thaumcraft.common.items.relics.ItemHandMirror;
+import thaumcraft.common.lib.network.fx.PacketFXShield;
+import thaumcraft.common.lib.utils.EntityUtils;
 
 public class EventHandlerEntity {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/ExplosionAlchemite.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/ExplosionAlchemite.java
@@ -29,6 +29,9 @@ import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
+
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -40,9 +43,6 @@ import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.ItemCrystalEssence;
 import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 import thaumcraft.common.tiles.TileNode;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
 
 public class ExplosionAlchemite extends Explosion {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
@@ -25,6 +25,11 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.gen.NoiseGeneratorOctaves;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntityMeatSlime;
+import com.kentington.thaumichorizons.common.entities.EntityMercurialSlime;
+import com.kentington.thaumichorizons.common.tiles.TileVortex;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.Config;
@@ -33,11 +38,6 @@ import thaumcraft.common.entities.monster.EntityTaintSporeSwarmer;
 import thaumcraft.common.entities.monster.EntityTaintacle;
 import thaumcraft.common.lib.utils.Utils;
 import thaumcraft.common.lib.world.ThaumcraftWorldGenerator;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntityMeatSlime;
-import com.kentington.thaumichorizons.common.entities.EntityMercurialSlime;
-import com.kentington.thaumichorizons.common.tiles.TileVortex;
 
 public class PocketPlaneData {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/THConfigGUI.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/THConfigGUI.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.common.config.ConfigElement;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import cpw.mods.fml.client.config.GuiConfig;
 
 public class THConfigGUI extends GuiConfig {

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/THKeyHandler.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/THKeyHandler.java
@@ -17,8 +17,6 @@ import net.minecraft.util.IChatComponent;
 
 import org.lwjgl.input.Keyboard;
 
-import thaumcraft.api.nodes.IRevealer;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.lib.networking.*;
 
@@ -29,6 +27,7 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.nodes.IRevealer;
 
 public class THKeyHandler {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketCowUpdate.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketCowUpdate.java
@@ -7,14 +7,13 @@ package com.kentington.thaumichorizons.common.lib.networking;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 
-import thaumcraft.api.aspects.AspectList;
-
 import com.kentington.thaumichorizons.common.entities.EntityWizardCow;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.api.aspects.AspectList;
 
 public class PacketCowUpdate implements IMessage, IMessageHandler<PacketCowUpdate, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXContainment.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXContainment.java
@@ -8,8 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.world.World;
 
-import thaumcraft.client.fx.ParticleEngine;
-
 import com.kentington.thaumichorizons.client.fx.FXContainment;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -18,6 +16,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.client.fx.ParticleEngine;
 
 public class PacketFXContainment implements IMessage, IMessageHandler<PacketFXContainment, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXEssentiaBubble.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXEssentiaBubble.java
@@ -8,8 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.world.World;
 
-import thaumcraft.client.fx.ParticleEngine;
-
 import com.kentington.thaumichorizons.client.fx.FXEssentiaBubble;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -18,6 +16,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.client.fx.ParticleEngine;
 
 public class PacketFXEssentiaBubble implements IMessage, IMessageHandler<PacketFXEssentiaBubble, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXInfusionDone.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketFXInfusionDone.java
@@ -7,13 +7,13 @@ package com.kentington.thaumichorizons.common.lib.networking;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.World;
 
-import thaumcraft.common.Thaumcraft;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.common.Thaumcraft;
 
 public class PacketFXInfusionDone implements IMessage, IMessageHandler<PacketFXInfusionDone, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketGetCowData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketGetCowData.java
@@ -10,9 +10,6 @@ import java.util.Set;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-
 import com.kentington.thaumichorizons.common.entities.EntityWizardCow;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -20,6 +17,8 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
 
 public class PacketGetCowData implements IMessage, IMessageHandler<PacketGetCowData, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketInfusionFX.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketInfusionFX.java
@@ -9,9 +9,6 @@ import java.util.HashMap;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.tiles.TilePedestal;
-
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 import com.kentington.thaumichorizons.common.tiles.TileVatSlave;
 
@@ -21,6 +18,8 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.tiles.TilePedestal;
 
 public class PacketInfusionFX implements IMessage, IMessageHandler<PacketInfusionFX, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketLensChangeToServer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketLensChangeToServer.java
@@ -9,8 +9,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 
-import thaumcraft.api.nodes.IRevealer;
-
 import com.kentington.thaumichorizons.common.items.lenses.LensManager;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
@@ -18,6 +16,7 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import thaumcraft.api.nodes.IRevealer;
 
 public class PacketLensChangeToServer implements IMessage, IMessageHandler<PacketLensChangeToServer, IMessage> {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileBloodInfuser.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileBloodInfuser.java
@@ -17,6 +17,8 @@ import net.minecraft.potion.Potion;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import thaumcraft.api.ThaumcraftApiHelper;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
@@ -24,8 +26,6 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectContainer;
 import thaumcraft.api.aspects.IEssentiaTransport;
 import thaumcraft.common.config.Config;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 public class TileBloodInfuser extends TileThaumcraft implements IAspectContainer, IEssentiaTransport, ISidedInventory {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileCloud.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileCloud.java
@@ -25,15 +25,6 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.damagesource.DamageSourceThaumcraft;
-import thaumcraft.common.config.Config;
-import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.config.ConfigItems;
-import thaumcraft.common.entities.EntityAspectOrb;
-import thaumcraft.common.entities.monster.EntityFireBat;
-
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityItemInvulnerable;
 import com.kentington.thaumichorizons.common.entities.EntityLightningBoltFinite;
@@ -43,6 +34,14 @@ import com.kentington.thaumichorizons.common.lib.networking.PacketRainState;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.damagesource.DamageSourceThaumcraft;
+import thaumcraft.common.config.Config;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.entities.EntityAspectOrb;
+import thaumcraft.common.entities.monster.EntityFireBat;
 
 public class TileCloud extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileInspiratron.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileInspiratron.java
@@ -13,10 +13,10 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.common.config.ConfigItems;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.config.ConfigItems;
 
 public class TileInspiratron extends TileThaumcraft implements ISoulReceiver, ISidedInventory {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileNodeMonitor.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileNodeMonitor.java
@@ -9,12 +9,12 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.blocks.BlockNodeMonitor;
+
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.nodes.INode;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.blocks.BlockNodeMonitor;
 
 public class TileNodeMonitor extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TilePortalTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TilePortalTH.java
@@ -11,11 +11,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.AxisAlignedBB;
 
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.common.Thaumcraft;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.Thaumcraft;
 
 public class TilePortalTH extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileRecombinator.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileRecombinator.java
@@ -8,6 +8,8 @@ import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -16,8 +18,6 @@ import thaumcraft.common.lib.network.PacketHandler;
 import thaumcraft.common.lib.network.fx.PacketFXBlockZap;
 import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileNode;
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class TileRecombinator extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSlot.java
@@ -7,14 +7,14 @@ package com.kentington.thaumichorizons.common.tiles;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.lib.PocketPlaneData;
+
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.items.wands.ItemWandCasting;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.lib.PocketPlaneData;
 
 public class TileSlot extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulBeacon.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulBeacon.java
@@ -11,10 +11,10 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.common.Thaumcraft;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.Thaumcraft;
 
 public class TileSoulBeacon extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulExtractor.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulExtractor.java
@@ -17,16 +17,15 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.visnet.TileVisNode;
 import thaumcraft.api.visnet.VisNetHandler;
 import thaumcraft.common.lib.utils.InventoryUtils;
 import thaumcraft.common.tiles.TileJarBrain;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class TileSoulExtractor extends TileVisNode implements ISidedInventory {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
@@ -15,6 +15,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
+import cpw.mods.fml.common.registry.VillagerRegistry;
 import thaumcraft.api.ThaumcraftApiHelper;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
@@ -23,9 +26,6 @@ import thaumcraft.api.aspects.IAspectContainer;
 import thaumcraft.api.aspects.IEssentiaTransport;
 import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.lib.utils.InventoryUtils;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import cpw.mods.fml.common.registry.VillagerRegistry;
 
 public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEssentiaTransport, IAspectContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileTransductionAmplifier.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileTransductionAmplifier.java
@@ -15,6 +15,11 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.DamageSource;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.blocks.BlockTransductionAmplifier;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -24,12 +29,6 @@ import thaumcraft.common.lib.network.fx.PacketFXBlockZap;
 import thaumcraft.common.tiles.TileNode;
 import thaumcraft.common.tiles.TileNodeConverter;
 import thaumcraft.common.tiles.TileNodeEnergized;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.blocks.BlockTransductionAmplifier;
-
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class TileTransductionAmplifier extends TileThaumcraft {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
@@ -40,23 +40,6 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import thaumcraft.api.ThaumcraftApiHelper;
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.aspects.IAspectContainer;
-import thaumcraft.api.aspects.IEssentiaTransport;
-import thaumcraft.api.crafting.IInfusionStabiliser;
-import thaumcraft.api.crafting.InfusionRecipe;
-import thaumcraft.api.visnet.VisNetHandler;
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.config.Config;
-import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.entities.golems.EntityGolemBase;
-import thaumcraft.common.lib.network.fx.PacketFXBlockZap;
-import thaumcraft.common.lib.utils.InventoryUtils;
-import thaumcraft.common.tiles.TilePedestal;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
@@ -73,6 +56,22 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.IAspectContainer;
+import thaumcraft.api.aspects.IEssentiaTransport;
+import thaumcraft.api.crafting.IInfusionStabiliser;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.visnet.VisNetHandler;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.config.Config;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.entities.golems.EntityGolemBase;
+import thaumcraft.common.lib.network.fx.PacketFXBlockZap;
+import thaumcraft.common.lib.utils.InventoryUtils;
+import thaumcraft.common.tiles.TilePedestal;
 
 public class TileVat extends TileThaumcraft implements IAspectContainer, IEssentiaTransport, ISidedInventory {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVatSlave.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVatSlave.java
@@ -6,12 +6,12 @@ package com.kentington.thaumichorizons.common.tiles;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectContainer;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 public class TileVatSlave extends TileThaumcraft implements IAspectContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -27,6 +27,11 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
+import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
+import com.kentington.thaumichorizons.common.lib.*;
+
+import cpw.mods.fml.common.FMLCommonHandler;
 import thaumcraft.api.ThaumcraftApiHelper;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
@@ -38,11 +43,6 @@ import thaumcraft.common.blocks.BlockAiry;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.entities.monster.EntityWisp;
 import thaumcraft.common.items.wands.ItemWandCasting;
-
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
-import com.kentington.thaumichorizons.common.entities.EntityGolemTH;
-import com.kentington.thaumichorizons.common.lib.*;
-import cpw.mods.fml.common.FMLCommonHandler;
 
 public class TileVortex extends TileThaumcraft implements IWandable, IAspectContainer {
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -58,7 +58,6 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
     public boolean generating;
     public boolean cheat;
     public ArrayList<ItemStack> items;
-    Thread ppThread;
 
     public TileVortex() {
         this.aspects = new AspectList();
@@ -68,7 +67,6 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
         this.generating = false;
         this.cheat = false;
         this.items = new ArrayList<ItemStack>();
-        this.ppThread = null;
     }
 
     public void updateEntity() {
@@ -82,16 +80,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                     (double) (this.zCoord + this.worldObj.rand.nextFloat()),
                     1.0f,
                     false);
-            if (this.ppThread == null) {
-                this.createDimension(null);
-                return;
-            }
-            if (!this.ppThread.isAlive()) {
-                this.generating = false;
-                this.createdDimension = true;
-                this.markDirty();
-                this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-            }
+            this.createDimension(null);
         } else {
             if (this.collapsing) {
                 ++this.count;
@@ -308,16 +297,17 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
         this.generating = true;
         if (!this.worldObj.isRemote) {
             this.returnID = this.worldObj.provider.dimensionId;
-            (this.ppThread = new Thread(
-                    new PocketPlaneThread(
-                            data,
-                            this.aspects,
-                            (World) MinecraftServer.getServer()
-                                    .worldServerForDimension(ThaumicHorizons.dimensionPocketId),
-                            this.xCoord,
-                            this.yCoord,
-                            this.zCoord,
-                            this.returnID))).run();
+            new PocketPlaneThread(
+                    data,
+                    this.aspects,
+                    MinecraftServer.getServer().worldServerForDimension(ThaumicHorizons.dimensionPocketId),
+                    this.xCoord,
+                    this.yCoord,
+                    this.zCoord,
+                    this.returnID);
+            this.generating = false;
+            this.createdDimension = true;
+            this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
         }
         this.markDirty();
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -15,17 +15,16 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import thaumcraft.api.TileThaumcraft;
-import thaumcraft.api.nodes.INode;
-import thaumcraft.api.nodes.NodeType;
-import thaumcraft.api.wands.IWandable;
-import thaumcraft.common.Thaumcraft;
-
 import com.kentington.thaumichorizons.client.fx.FXSonic;
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.nodes.INode;
+import thaumcraft.api.nodes.NodeType;
+import thaumcraft.api.wands.IWandable;
+import thaumcraft.common.Thaumcraft;
 
 public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
 


### PR DESCRIPTION
The threading was not working because `Thread.run()` does not start a new thread. `Thread.start()` should've been used for that.
What is more, the threading was not safe because getting World is not a thread-safe operation, so threading was removed altogether from this part.
    
First two `if`s can be summarized as "if dimension is not created then create it, and if it's already created then handle it".
    
Because `createDimension` is now single-threaded, we can call it without checking if it's already in the process of creating a dimension. The handling of creating a dimension was put in `createDimension`.