### PR TITLE
Switch decompiler constants to their named variants

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/fx/FXContainment.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/fx/FXContainment.java
@@ -48,8 +48,8 @@ public class FXContainment extends EntityFX {
         UtilsFX.bindTexture(FXContainment.portaltex);
         GL11.glPushMatrix();
         GL11.glDepthMask(false);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         final float f6 = 3.0f * this.particleScale;
         final float f7 = (float) (this.posX - FXContainment.interpPosX);
         final float f8 = (float) (this.posY - FXContainment.interpPosY);
@@ -79,7 +79,7 @@ public class FXContainment extends EntityFX {
                 f9 + p_70539_5_ * f6 - p_70539_7_ * f6,
                 f2,
                 f5);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glDepthMask(true);
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/fx/FXSonic.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/fx/FXSonic.java
@@ -69,9 +69,9 @@ public class FXSonic extends EntityFX {
             final float f3, final float f4, final float f5) {
         tessellator.draw();
         GL11.glPushMatrix();
-        GL11.glDisable(2884);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glDisable(GL11.GL_CULL_FACE);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         if (model == null) {
             model = AdvancedModelLoader.loadModel(FXSonic.MODEL);
         }
@@ -93,8 +93,8 @@ public class FXSonic extends EntityFX {
         GL11.glScaled(0.5, 0.5, -0.5);
         GL11.glColor4f(0.0f, b, b, 1.0f);
         model.renderAll();
-        GL11.glDisable(3042);
-        GL11.glEnable(2884);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glPopMatrix();
         Minecraft.getMinecraft().renderEngine.bindTexture(UtilsFX.getParticleTexture());
         tessellator.startDrawingQuads();

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiBloodInfuser.java
@@ -76,13 +76,13 @@ public class GuiBloodInfuser extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guibloodinfuser.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 
@@ -90,7 +90,7 @@ public class GuiBloodInfuser extends GuiContainer {
         this.drawEssentiaSelected();
         this.drawAspectList();
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guibloodinfuser.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         if (this.canScrollLeft()) {
@@ -234,7 +234,7 @@ public class GuiBloodInfuser extends GuiContainer {
             --this.flashTimer;
             this.drawFlash();
         }
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 
@@ -419,10 +419,10 @@ public class GuiBloodInfuser extends GuiContainer {
     void drawQuestionMark(final int x, final int y, final Color color) {
         final Minecraft mc = Minecraft.getMinecraft();
         GL11.glPushMatrix();
-        GL11.glDisable(2896);
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glDisable(GL11.GL_LIGHTING);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glPushMatrix();
         mc.renderEngine.bindTexture(new ResourceLocation("thaumcraft", "textures/aspects/_unknown.png"));
         GL11.glColor4f(color.getRed() / 255.0f, color.getGreen() / 255.0f, color.getBlue() / 255.0f, 0.8f);
@@ -435,10 +435,10 @@ public class GuiBloodInfuser extends GuiContainer {
         var9.addVertexWithUV(x + 0.0, y + 0.0, this.zLevel, 0.0, 0.0);
         var9.draw();
         GL11.glPopMatrix();
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-        GL11.glAlphaFunc(516, 0.1f);
-        GL11.glEnable(2896);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
+        GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiCase.java
@@ -33,9 +33,9 @@ public class GuiCase extends GuiContainer {
         UtilsFX.bindTexture("textures/gui/gui_focuspouch.png");
         final float t = this.zLevel;
         this.zLevel = 200.0f;
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         this.drawTexturedModalRect(8 + this.blockSlot * 18, 209, 240, 0, 16, 16);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         this.zLevel = t;
     }
 
@@ -51,8 +51,8 @@ public class GuiCase extends GuiContainer {
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiFingers.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiFingers.java
@@ -46,11 +46,11 @@ public class GuiFingers extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float par1, final int par2, final int par3) {
         UtilsFX.bindTexture("thaumichorizons", "textures/gui/guifingers.png");
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         ItemWandCasting wand = null;
         if (this.tileEntity.getStackInSlot(10) != null
                 && this.tileEntity.getStackInSlot(10).getItem() instanceof ItemWandCasting) {
@@ -97,9 +97,9 @@ public class GuiFingers extends GuiContainer {
             final float var7 = 0.33f;
             GL11.glColor4f(var7, var7, var7, 0.66f);
             GuiFingers.itemRender.renderWithColor = false;
-            GL11.glEnable(2896);
-            GL11.glEnable(2884);
-            GL11.glEnable(3042);
+            GL11.glEnable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_CULL_FACE);
+            GL11.glEnable(GL11.GL_BLEND);
             GuiFingers.itemRender.renderItemAndEffectIntoGUI(
                     this.mc.fontRenderer,
                     this.mc.renderEngine,
@@ -113,8 +113,8 @@ public class GuiFingers extends GuiContainer {
                     var5 + 160,
                     var6 + 64);
             GuiFingers.itemRender.renderWithColor = true;
-            GL11.glDisable(3042);
-            GL11.glDisable(2896);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glPopMatrix();
             GL11.glPushMatrix();
             GL11.glTranslatef((float) (var5 + 168), (float) (var6 + 46), 0.0f);

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInjector.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInjector.java
@@ -25,13 +25,13 @@ public class GuiInjector extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guiinjector.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInspiratron.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiInspiratron.java
@@ -29,7 +29,7 @@ public class GuiInspiratron extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guiinspiratron.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
@@ -37,7 +37,7 @@ public class GuiInspiratron extends GuiContainer {
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
         final int i1 = this.tile.getTimeRemainingScaled(28);
         this.drawTexturedModalRect(var5 + 66, var6 + 102, 176, 158 - i1, 44, i1);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulExtractor.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulExtractor.java
@@ -29,7 +29,7 @@ public class GuiSoulExtractor extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guisieve.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
@@ -39,7 +39,7 @@ public class GuiSoulExtractor extends GuiContainer {
             final int i1 = this.tile.getTimeRemainingScaled(39);
             this.drawTexturedModalRect(var5 + 91, var6 + 58 - i1, 176, 166 - i1, 35, i1);
         }
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulforge.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiSoulforge.java
@@ -31,13 +31,13 @@ public class GuiSoulforge extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guidynamo.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVat.java
@@ -34,7 +34,7 @@ public class GuiVat extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(final float p_146976_1_, final int p_146976_2_,
             final int p_146976_3_) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guivat.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
@@ -114,7 +114,7 @@ public class GuiVat extends GuiContainer {
                         16);
             }
         }
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVisDynamo.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/gui/GuiVisDynamo.java
@@ -43,13 +43,13 @@ public class GuiVisDynamo extends GuiContainer {
 
     protected void drawGuiContainerBackgroundLayer(final float par1, final int par2, final int par3) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
+        GL11.glEnable(GL11.GL_BLEND);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", "textures/gui/guidynamo.png"));
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         final int var5 = (this.width - this.xSize) / 2;
         final int var6 = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(var5, var6, 0, 0, this.xSize, this.ySize);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
@@ -30,6 +30,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityBoatThaumium;
@@ -245,14 +246,14 @@ public class RenderEventHandler {
             return;
         }
         GL11.glPushMatrix();
-        GL11.glClear(256);
-        GL11.glMatrixMode(5889);
+        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
+        GL11.glMatrixMode(GL11.GL_PROJECTION);
         GL11.glLoadIdentity();
         GL11.glOrtho(0.0, sw, sh, 0.0, 1000.0, 3000.0);
-        GL11.glMatrixMode(5888);
+        GL11.glMatrixMode(GL11.GL_MODELVIEW);
         GL11.glLoadIdentity();
         GL11.glTranslatef(0.0f, 0.0f, -2000.0f);
-        GL11.glDisable(2929);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
         GL11.glDepthMask(false);
         GL11.glPushMatrix();
         GL11.glTranslated(sw / 2.0, sh / 2.0, 0.0);
@@ -261,9 +262,9 @@ public class RenderEventHandler {
         UtilsFX.bindTexture("textures/misc/radial.png");
         GL11.glPushMatrix();
         GL11.glRotatef(partialTicks + mc.thePlayer.ticksExisted % 720 / 2.0f, 0.0f, 0.0f, 1.0f);
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         UtilsFX.renderQuadCenteredFromTexture(
                 width * 2.75f * RenderEventHandler.radialHudScale,
                 0.5f,
@@ -272,15 +273,15 @@ public class RenderEventHandler {
                 200,
                 771,
                 0.5f);
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         GL11.glPopMatrix();
         UtilsFX.bindTexture("textures/misc/radial2.png");
         GL11.glPushMatrix();
         GL11.glRotatef(-(partialTicks + mc.thePlayer.ticksExisted % 720 / 2.0f), 0.0f, 0.0f, 1.0f);
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         UtilsFX.renderQuadCenteredFromTexture(
                 width * 2.55f * RenderEventHandler.radialHudScale,
                 0.5f,
@@ -289,18 +290,18 @@ public class RenderEventHandler {
                 200,
                 771,
                 0.5f);
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         GL11.glPopMatrix();
         if (lens != null) {
             GL11.glPushMatrix();
-            GL11.glEnable(32826);
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             RenderHelper.enableGUIStandardItemLighting();
             final ItemStack item = new ItemStack((Item) lens);
             item.stackTagCompound = null;
             ri.renderItemIntoGUI(mc.fontRenderer, mc.renderEngine, item, -8, -8);
             RenderHelper.disableStandardItemLighting();
-            GL11.glDisable(32826);
+            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
             GL11.glPopMatrix();
             final int mx = (int) (i - sw / 2.0);
             final int my = (int) (j - sh / 2.0);
@@ -316,19 +317,19 @@ public class RenderEventHandler {
         final float pieSlice = 360.0f / this.fociItem.size();
         String key = this.foci.firstKey();
         for (int a = 0; a < this.fociItem.size(); ++a) {
-            final double xx = MathHelper.cos(currentRot / 180.0f * 3.141593f) * width;
-            final double yy = MathHelper.sin(currentRot / 180.0f * 3.141593f) * width;
+            final double xx = MathHelper.cos(currentRot / 180.0f * (float) Math.PI) * width;
+            final double yy = MathHelper.sin(currentRot / 180.0f * (float) Math.PI) * width;
             currentRot += pieSlice;
             GL11.glPushMatrix();
             GL11.glTranslated(xx, yy, 100.0);
             GL11.glScalef(this.fociScale.get(key), this.fociScale.get(key), this.fociScale.get(key));
-            GL11.glEnable(32826);
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             RenderHelper.enableGUIStandardItemLighting();
             final ItemStack item2 = this.fociItem.get(key).copy();
             item2.stackTagCompound = null;
             ri.renderItemIntoGUI(mc.fontRenderer, mc.renderEngine, item2, -8, -8);
             RenderHelper.disableStandardItemLighting();
-            GL11.glDisable(32826);
+            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
             GL11.glPopMatrix();
             if (!THKeyHandler.radialLock && THKeyHandler.radialActive) {
                 final int mx2 = (int) (i - sw / 2.0 - xx);
@@ -360,8 +361,8 @@ public class RenderEventHandler {
                     11);
         }
         GL11.glDepthMask(true);
-        GL11.glEnable(2929);
-        GL11.glDisable(3042);
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockBloodInfuserRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockBloodInfuserRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileBloodInfuser;
@@ -27,7 +28,7 @@ public class BlockBloodInfuserRender extends BlockRenderer implements ISimpleBlo
         final TileBloodInfuser tc = new TileBloodInfuser();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockEssentiaDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockEssentiaDynamoRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileEssentiaDynamo;
@@ -27,7 +28,7 @@ public class BlockEssentiaDynamoRender extends BlockRenderer implements ISimpleB
         final TileEssentiaDynamo tc = new TileEssentiaDynamo();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockInspiratronRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockInspiratronRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
@@ -27,7 +28,7 @@ public class BlockInspiratronRender extends BlockRenderer implements ISimpleBloc
         final TileInspiratron tc = new TileInspiratron();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockJarTHRenderer.java
@@ -24,8 +24,8 @@ public class BlockJarTHRenderer extends BlockRenderer implements ISimpleBlockRen
     public void renderInventoryBlock(final Block block, final int metadata, final int modelID,
             final RenderBlocks renderer) {
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
         final IIcon i1 = ((BlockSoulJar) block).iconJarTop;
         final IIcon i2 = ((BlockSoulJar) block).iconJarSide;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockNodeMonitorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockNodeMonitorRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileNodeMonitor;
@@ -27,7 +28,7 @@ public class BlockNodeMonitorRender extends BlockRenderer implements ISimpleBloc
         final TileNodeMonitor tc = new TileNodeMonitor();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockRecombinatorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockRecombinatorRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileRecombinator;
@@ -28,7 +29,7 @@ public class BlockRecombinatorRender extends BlockRenderer implements ISimpleBlo
         tc.blockType = ThaumicHorizons.blockRecombinator;
         tc.blockMetadata = 0;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSlotRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSlotRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSlot;
@@ -28,7 +29,7 @@ public class BlockSlotRender extends BlockRenderer implements ISimpleBlockRender
         tc.blockType = ThaumicHorizons.blockSlot;
         tc.blockMetadata = 0;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulBeaconRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulBeaconRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulBeacon;
@@ -27,7 +28,7 @@ public class BlockSoulBeaconRender extends BlockRenderer implements ISimpleBlock
         final TileSoulBeacon tc = new TileSoulBeacon();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulSieveRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulSieveRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulExtractor;
@@ -27,7 +28,7 @@ public class BlockSoulSieveRender extends BlockRenderer implements ISimpleBlockR
         final TileSoulExtractor tc = new TileSoulExtractor();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulforgeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSoulforgeRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSoulforge;
@@ -27,7 +28,7 @@ public class BlockSoulforgeRender extends BlockRenderer implements ISimpleBlockR
         final TileSoulforge tc = new TileSoulforge();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSpikeRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSpikeRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSpike;
@@ -33,7 +34,7 @@ public class BlockSpikeRenderer extends BlockRenderer implements ISimpleBlockRen
         final TileSpike tc = new TileSpike((byte) 1, type);
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSyntheticNodeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockSyntheticNodeRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
@@ -27,7 +28,7 @@ public class BlockSyntheticNodeRender extends BlockRenderer implements ISimpleBl
         final TileSyntheticNode tc = new TileSyntheticNode();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockTransductionAmplifierRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockTransductionAmplifierRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileTransductionAmplifier;
@@ -27,7 +28,7 @@ public class BlockTransductionAmplifierRender extends BlockRenderer implements I
         final TileTransductionAmplifier tc = new TileTransductionAmplifier();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatMatrixRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVatMatrixRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVatMatrix;
@@ -27,7 +28,7 @@ public class BlockVatMatrixRender extends BlockRenderer implements ISimpleBlockR
         final TileVatMatrix tc = new TileVatMatrix();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVisDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVisDynamoRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVisDynamo;
@@ -27,7 +28,7 @@ public class BlockVisDynamoRender extends BlockRenderer implements ISimpleBlockR
         final TileVisDynamo tc = new TileVisDynamo();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVortexStabilizerRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/block/BlockVortexStabilizerRender.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileVortexStabilizer;
@@ -27,7 +28,7 @@ public class BlockVortexStabilizerRender extends BlockRenderer implements ISimpl
         final TileVortexStabilizer tc = new TileVortexStabilizer();
         tc.blockMetadata = metadata;
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tc, 0.0, 0.0, 0.0, 0.0f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/BlastPhialRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/BlastPhialRender.java
@@ -15,6 +15,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
@@ -33,7 +34,7 @@ public class BlastPhialRender extends RenderSnowball {
         if (iicon != null) {
             GL11.glPushMatrix();
             GL11.glTranslatef((float) p_76986_2_, (float) p_76986_4_, (float) p_76986_6_);
-            GL11.glEnable(32826);
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             GL11.glScalef(0.5f, 0.5f, 0.5f);
             this.bindEntityTexture(p_76986_1_);
             final Tessellator tessellator = Tessellator.instance;
@@ -46,7 +47,7 @@ public class BlastPhialRender extends RenderSnowball {
             this.func_77026_a(tessellator, iicon);
             GL11.glPopMatrix();
             GL11.glColor3f(1.0f, 1.0f, 1.0f);
-            GL11.glDisable(32826);
+            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderAlchemitePrimed.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderAlchemitePrimed.java
@@ -53,16 +53,16 @@ public class RenderAlchemitePrimed extends RenderEntity {
         this.bindEntityTexture(entity);
         this.blockRenderer.renderBlockAsItem(ThaumicHorizons.blockAlchemite, 0, entity.getBrightness(p_76986_9_));
         if (entity.fuse / 5 % 2 == 0) {
-            GL11.glDisable(3553);
-            GL11.glDisable(2896);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 772);
+            GL11.glDisable(GL11.GL_TEXTURE_2D);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_DST_ALPHA);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, f2);
             this.blockRenderer.renderBlockAsItem(ThaumicHorizons.blockAlchemite, 0, 1.0f);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-            GL11.glDisable(3042);
-            GL11.glEnable(2896);
-            GL11.glEnable(3553);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glEnable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
         }
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderGolemTH.java
@@ -92,8 +92,8 @@ public class RenderGolemTH extends RenderGolemBase {
             final int upgrades = ((EntityGolemTH) entity).upgrades.length;
             final float shift = 0.08f;
             GL11.glPushMatrix();
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             for (int a = 0; a < upgrades; ++a) {
                 GL11.glPushMatrix();
                 GL11.glRotatef(180.0f, 1.0f, 0.0f, 0.0f);
@@ -116,7 +116,7 @@ public class RenderGolemTH extends RenderGolemBase {
                 tessellator2.draw();
                 GL11.glPopMatrix();
             }
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glPopMatrix();
         } else {
             if (pass == 1 && (((EntityGolemTH) entity).getGolemDecoration().length() > 0

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLightningBoltFinite.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLightningBoltFinite.java
@@ -22,10 +22,10 @@ public class RenderLightningBoltFinite extends RenderLightningBolt {
     public void doRender(final EntityLightningBoltFinite p_76986_1_, final double p_76986_2_, final double p_76986_4_,
             final double p_76986_6_, final float p_76986_8_, final float p_76986_9_) {
         final Tessellator tessellator = Tessellator.instance;
-        GL11.glDisable(3553);
-        GL11.glDisable(2896);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GL11.glDisable(GL11.GL_LIGHTING);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         final double[] adouble = new double[8];
         final double[] adouble2 = new double[8];
         double d3 = 0.0;
@@ -102,8 +102,8 @@ public class RenderLightningBoltFinite extends RenderLightningBolt {
                 }
             }
         }
-        GL11.glDisable(3042);
-        GL11.glEnable(2896);
-        GL11.glEnable(3553);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glEnable(GL11.GL_LIGHTING);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLunarWolf.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderLunarWolf.java
@@ -36,12 +36,12 @@ public class RenderLunarWolf extends RenderWolf {
         }
         final float scale = p_76986_1_.worldObj.getCurrentMoonPhaseFactor() * 3.0f;
         GL11.glPushMatrix();
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         GL11.glPushMatrix();
         GL11.glDepthMask(false);
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         final int i = p_76986_1_.ticksExisted % 32;
         UtilsFX.bindTexture(TileNodeRenderer.nodetex);
         UtilsFX.renderFacingStrip(
@@ -56,11 +56,11 @@ public class RenderLunarWolf extends RenderWolf {
                 i,
                 p_76986_9_,
                 11197951);
-        GL11.glEnable(2884);
+        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glDepthMask(true);
         GL11.glPopMatrix();
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderSoul.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderSoul.java
@@ -44,8 +44,8 @@ public class RenderSoul extends Render {
         final Tessellator tessellator = Tessellator.instance;
         GL11.glPushMatrix();
         GL11.glDepthMask(false);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         UtilsFX.bindTexture("thaumichorizons", "textures/misc/soul.png");
         final int i = entity.ticksExisted % 16;
         final float x2 = i / this.size1;
@@ -57,7 +57,7 @@ public class RenderSoul extends Render {
         tessellator.addVertexWithUV(f7 + f1 * f6 + f4 * f6, f8 + f2 * f6, f9 + f3 * f6 + f5 * f6, x2, 1.0);
         tessellator.addVertexWithUV(f7 + f1 * f6 - f4 * f6, f8 - f2 * f6, f9 + f3 * f6 - f5 * f6, x2, 0.0);
         tessellator.draw();
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glDepthMask(true);
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderTaintfeeder.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderTaintfeeder.java
@@ -37,12 +37,12 @@ public class RenderTaintfeeder extends RenderPig {
             final double p_76986_6_, final float p_76986_8_, final float p_76986_9_) {
         super.doRender(p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
         GL11.glPushMatrix();
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         GL11.glPushMatrix();
         GL11.glDepthMask(false);
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         final int i = p_76986_1_.ticksExisted % 32;
         UtilsFX.bindTexture(TileNodeRenderer.nodetex);
         UtilsFX.renderFacingStrip(
@@ -57,11 +57,11 @@ public class RenderTaintfeeder extends RenderPig {
                 i,
                 p_76986_9_,
                 11197951);
-        GL11.glEnable(2884);
+        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glDepthMask(true);
         GL11.glPopMatrix();
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         GL11.glPopMatrix();
     }
 
@@ -90,9 +90,9 @@ public class RenderTaintfeeder extends RenderPig {
         }
         final float f = (float) Math.sin(Math.toRadians(p_77032_1_.ticksExisted % 45) * 8.0);
         this.bindTexture(RenderTaintfeeder.pigEyesTextures);
-        GL11.glEnable(3042);
-        GL11.glDisable(3008);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glDisable(GL11.GL_ALPHA_TEST);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glDepthMask(!p_77032_1_.isInvisible());
         final char c0 = '\uf0f0';
         final int j = c0 % 65536;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderWizardCow.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/entity/RenderWizardCow.java
@@ -37,8 +37,8 @@ public class RenderWizardCow extends RenderCow {
 
     public void doRender(final EntityWizardCow p_76986_1_, final double p_76986_2_, final double p_76986_4_,
             final double p_76986_6_, final float p_76986_8_, final float p_76986_9_) {
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 0.5f);
         super.doRender(p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
@@ -57,7 +57,7 @@ public class RenderWizardCow extends RenderCow {
                     RenderWizardCow.cowTypes.get(p_76986_1_.getUniqueID().toString()),
                     RenderWizardCow.cowMods.get(p_76986_1_.getUniqueID().toString()));
         }
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
     }
 
     public void renderMyNode(final double x, final double y, final double z, final EntityLivingBase viewer,
@@ -86,16 +86,16 @@ public class RenderWizardCow extends RenderCow {
                 }
             }
             GL11.glPushMatrix();
-            GL11.glAlphaFunc(516, 0.003921569f);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
             GL11.glDepthMask(false);
             if (depthIgnore) {
-                GL11.glDisable(2929);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
             }
-            GL11.glDisable(2884);
+            GL11.glDisable(GL11.GL_CULL_FACE);
             final long time = nt / 5000000L;
             final float bscale = 0.25f;
             GL11.glPushMatrix();
-            final float rad = 6.283186f;
+            final float rad = ((float) Math.PI * 2F);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, alpha);
             int i = (int) ((nt / 40000000L + x) % frames);
             int count = 0;
@@ -108,8 +108,8 @@ public class RenderWizardCow extends RenderCow {
                 }
                 average += aspects.getAmount(aspect);
                 GL11.glPushMatrix();
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, aspect.getBlend());
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, aspect.getBlend());
                 scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                 scale = 0.2f + scale * (aspects.getAmount(aspect) / 50.0f);
                 scale *= size;
@@ -126,7 +126,7 @@ public class RenderWizardCow extends RenderCow {
                         i,
                         partialTicks,
                         aspect.getColor());
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
                 GL11.glPopMatrix();
                 ++count;
                 if (aspect.getBlend() == 771) {
@@ -135,62 +135,62 @@ public class RenderWizardCow extends RenderCow {
             }
             average /= aspects.size();
             GL11.glPushMatrix();
-            GL11.glEnable(3042);
+            GL11.glEnable(GL11.GL_BLEND);
             i = (int) ((nt / 40000000L + x) % frames);
             scale = 0.1f + average / 150.0f;
             scale *= size;
             int strip = 1;
             switch (type) {
                 case NORMAL -> {
-                    GL11.glBlendFunc(770, 1);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
                 }
                 case UNSTABLE -> {
-                    GL11.glBlendFunc(770, 1);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
                     strip = 6;
                     angle = 0.0f;
                 }
                 case DARK -> {
-                    GL11.glBlendFunc(770, 771);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                     strip = 2;
                 }
                 case TAINTED -> {
-                    GL11.glBlendFunc(770, 771);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                     strip = 5;
                 }
                 case HUNGRY -> {
-                    GL11.glBlendFunc(770, 1);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
                     strip = 4;
                 }
                 case PURE -> {
                     scale *= 0.75f;
-                    GL11.glBlendFunc(770, 1);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
                     strip = 3;
                 }
             }
             GL11.glColor4f(1.0f, 0.0f, 1.0f, alpha);
             UtilsFX.renderFacingStrip(x, y, z, angle, scale, alpha, frames, strip, i, partialTicks, 16777215);
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glPopMatrix();
             GL11.glPopMatrix();
-            GL11.glEnable(2884);
+            GL11.glEnable(GL11.GL_CULL_FACE);
             if (depthIgnore) {
-                GL11.glEnable(2929);
+                GL11.glEnable(GL11.GL_DEPTH_TEST);
             }
             GL11.glDepthMask(true);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             GL11.glPopMatrix();
         } else {
             GL11.glPushMatrix();
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 1);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
             GL11.glDepthMask(false);
             final int j = (int) ((nt / 40000000L + x) % frames);
             GL11.glColor4f(1.0f, 0.0f, 1.0f, 0.1f);
             UtilsFX.renderFacingStrip(x, y, z, 0.0f, 0.5f, 0.1f, frames, 1, j, partialTicks, 16777215);
             GL11.glDepthMask(true);
-            GL11.glDisable(3042);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemInjectorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemInjectorRender.java
@@ -77,7 +77,14 @@ public class ItemInjectorRender implements IItemRenderer {
             GL11.glRotatef(90.0f, 0.0f, 1.0f, 0.0f);
         }
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", this.tx1));
-        this.injector.render(null, f * 3.1415927f / 16.0f, f * 3.1415927f / 4.0f, (float) rotation, f, 0.0f, 0.125f);
+        this.injector.render(
+                null,
+                f * (float) Math.PI / 16.0f,
+                f * (float) Math.PI / 4.0f,
+                (float) rotation,
+                f,
+                0.0f,
+                0.125f);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemSyringeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/item/ItemSyringeRender.java
@@ -58,11 +58,11 @@ public class ItemSyringeRender implements IItemRenderer {
         } else {
             GL11.glTranslated(0.0, -2.75, 0.0);
         }
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         UtilsFX.bindTexture(new ResourceLocation("thaumichorizons", this.tx1));
         this.syringe.render(null, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.125f, item);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelFamiliar.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelFamiliar.java
@@ -39,17 +39,17 @@ public class ModelFamiliar extends ModelBase {
         this.Body.setRotationPoint(0.0f, 12.0f, -10.0f);
         this.Body.setTextureSize(64, 32);
         this.Body.mirror = true;
-        this.setRotation(this.Body, 1.570796f, 0.0f, 0.0f);
+        this.setRotation(this.Body, ((float) Math.PI / 2F), 0.0f, 0.0f);
         (this.Tail1 = new ModelRenderer(this, 0, 15)).addBox(-0.5f, 0.0f, 0.0f, 1, 8, 1);
         this.Tail1.setRotationPoint(0.0f, 15.0f, 8.0f);
         this.Tail1.setTextureSize(64, 32);
         this.Tail1.mirror = true;
-        this.setRotation(this.Tail1, 1.570796f, 0.0f, 0.0f);
+        this.setRotation(this.Tail1, ((float) Math.PI / 2F), 0.0f, 0.0f);
         (this.Tail2 = new ModelRenderer(this, 4, 15)).addBox(-0.5f, 0.0f, 0.0f, 1, 8, 1);
         this.Tail2.setRotationPoint(0.0f, 15.0f, 14.0f);
         this.Tail2.setTextureSize(64, 32);
         this.Tail2.mirror = true;
-        this.setRotation(this.Tail2, 1.570796f, 0.0f, 0.0f);
+        this.setRotation(this.Tail2, ((float) Math.PI / 2F), 0.0f, 0.0f);
         (this.LegBackL = new ModelRenderer(this, 8, 13)).addBox(-1.0f, 0.0f, 1.0f, 2, 6, 2);
         this.LegBackL.setRotationPoint(1.1f, 18.0f, 5.0f);
         this.LegBackL.setTextureSize(64, 32);
@@ -146,40 +146,44 @@ public class ModelFamiliar extends ModelBase {
 
     public void setRotationAngles(final float p_78087_1_, final float p_78087_2_, final float p_78087_3_,
             final float p_78087_4_, final float p_78087_5_, final float p_78087_6_, final Entity p_78087_7_) {
-        this.Main.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.Main.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.Nose.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.Nose.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.Ear1.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.Ear1.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.Ear2.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.Ear2.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.HatA.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.HatA.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.HatB.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.HatB.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.HatC.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.HatC.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.HatBuckle.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.HatBuckle.rotateAngleY = p_78087_4_ / 57.295776f;
-        this.HatBase.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.HatBase.rotateAngleY = p_78087_4_ / 57.295776f;
+        this.Main.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.Main.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.Nose.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.Nose.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.Ear1.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.Ear1.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.Ear2.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.Ear2.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.HatA.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.HatA.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.HatB.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.HatB.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.HatC.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.HatC.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.HatBuckle.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.HatBuckle.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
+        this.HatBase.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.HatBase.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
         if (this.field_78163_i != 3) {
-            this.Body.rotateAngleX = 1.5707964f;
+            this.Body.rotateAngleX = ((float) Math.PI / 2F);
             if (this.field_78163_i == 2) {
                 this.LegBackL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
                 this.LegBackR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 0.3f) * 1.0f * p_78087_2_;
-                this.LegFrontL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f + 0.3f) * 1.0f
+                this.LegFrontL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI + 0.3f) * 1.0f
                         * p_78087_2_;
-                this.LegFrontR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f * p_78087_2_;
-                this.Tail2.rotateAngleX = 1.7278761f + 0.31415927f * MathHelper.cos(p_78087_1_) * p_78087_2_;
+                this.LegFrontR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f
+                        * p_78087_2_;
+                this.Tail2.rotateAngleX = 1.7278761f
+                        + ((float) Math.PI / 10F) * MathHelper.cos(p_78087_1_) * p_78087_2_;
             } else {
                 this.LegBackL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
-                this.LegBackR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f * p_78087_2_;
-                this.LegFrontL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f * p_78087_2_;
+                this.LegBackR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f * p_78087_2_;
+                this.LegFrontL.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f
+                        * p_78087_2_;
                 this.LegFrontR.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
                 if (this.field_78163_i == 1) {
-                    this.Tail2.rotateAngleX = 1.7278761f + 0.7853982f * MathHelper.cos(p_78087_1_) * p_78087_2_;
+                    this.Tail2.rotateAngleX = 1.7278761f
+                            + ((float) Math.PI / 4F) * MathHelper.cos(p_78087_1_) * p_78087_2_;
                 } else {
                     this.Tail2.rotateAngleX = 1.7278761f + 0.47123894f * MathHelper.cos(p_78087_1_) * p_78087_2_;
                 }
@@ -262,18 +266,18 @@ public class ModelFamiliar extends ModelBase {
             tail2.rotationPointY -= 4.0f;
             final ModelRenderer tail3 = this.Tail2;
             tail3.rotationPointZ += 2.0f;
-            this.Tail1.rotateAngleX = 1.5707964f;
-            this.Tail2.rotateAngleX = 1.5707964f;
+            this.Tail1.rotateAngleX = ((float) Math.PI / 2F);
+            this.Tail2.rotateAngleX = ((float) Math.PI / 2F);
             this.field_78163_i = 0;
         } else if (entityocelot.isSprinting()) {
             this.Tail2.rotationPointY = this.Tail1.rotationPointY;
             final ModelRenderer tail4 = this.Tail2;
             tail4.rotationPointZ += 2.0f;
-            this.Tail1.rotateAngleX = 1.5707964f;
-            this.Tail2.rotateAngleX = 1.5707964f;
+            this.Tail1.rotateAngleX = ((float) Math.PI / 2F);
+            this.Tail2.rotateAngleX = ((float) Math.PI / 2F);
             this.field_78163_i = 2;
         } else if (entityocelot.isSitting()) {
-            this.Body.rotateAngleX = 0.7853982f;
+            this.Body.rotateAngleX = ((float) Math.PI / 4F);
             final ModelRenderer body2 = this.Body;
             body2.rotationPointY -= 4.0f;
             final ModelRenderer body3 = this.Body;
@@ -341,7 +345,7 @@ public class ModelFamiliar extends ModelBase {
             legFrontL5.rotationPointZ = n7;
             final ModelRenderer legBackL3 = this.LegBackL;
             final ModelRenderer legBackR3 = this.LegBackR;
-            final float n8 = -1.5707964f;
+            final float n8 = -((float) Math.PI / 2F);
             legBackR3.rotateAngleX = n8;
             legBackL3.rotateAngleX = n8;
             final ModelRenderer legBackL4 = this.LegBackL;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelGolemTH.java
@@ -28,8 +28,8 @@ public class ModelGolemTH extends ModelGolem {
                 GL11.glColor3f(0.5f + h1, 0.9f + h2, 0.5f + h1);
             }
         }
-        this.golemHead.rotateAngleY = par4 / 57.295776f;
-        this.golemHead.rotateAngleX = par5 / 57.295776f;
+        this.golemHead.rotateAngleY = par4 / (180F / (float) Math.PI);
+        this.golemHead.rotateAngleX = par5 / (180F / (float) Math.PI);
         this.golemRightLeg.rotateAngleX = -1.5f * this.func_78172_a(par1, 13.0f) * par2;
         this.golemLeftLeg.rotateAngleX = 1.5f * this.func_78172_a(par1, 13.0f) * par2;
         this.golemRightLeg.rotateAngleY = 0.0f;
@@ -38,8 +38,8 @@ public class ModelGolemTH extends ModelGolem {
         this.golemRightArm.rotateAngleZ = 0.0f;
         if (core == 6) {
             final float s = (1.0f - (0.5f + Math.min(64, ((EntityGolemBase) en).getCarryLimit()) / 128.0f)) * 25.0f;
-            this.golemLeftArm.rotateAngleZ = s / 57.295776f;
-            this.golemRightArm.rotateAngleZ = -s / 57.295776f;
+            this.golemLeftArm.rotateAngleZ = s / (180F / (float) Math.PI);
+            this.golemRightArm.rotateAngleZ = -s / (180F / (float) Math.PI);
         }
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelGuardianPanther.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelGuardianPanther.java
@@ -92,27 +92,30 @@ public class ModelGuardianPanther extends ModelBase {
 
     public void setRotationAngles(final float p_78087_1_, final float p_78087_2_, final float p_78087_3_,
             final float p_78087_4_, final float p_78087_5_, final float p_78087_6_, final Entity p_78087_7_) {
-        this.ocelotHead.rotateAngleX = p_78087_5_ / 57.295776f;
-        this.ocelotHead.rotateAngleY = p_78087_4_ / 57.295776f;
+        this.ocelotHead.rotateAngleX = p_78087_5_ / (180F / (float) Math.PI);
+        this.ocelotHead.rotateAngleY = p_78087_4_ / (180F / (float) Math.PI);
         if (this.field_78163_i != 3) {
-            this.ocelotBody.rotateAngleX = 1.5707964f;
+            this.ocelotBody.rotateAngleX = ((float) Math.PI / 2F);
             if (this.field_78163_i == 2) {
                 this.ocelotBackLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
                 this.ocelotBackRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 0.3f) * 1.0f * p_78087_2_;
-                this.ocelotFrontLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f + 0.3f) * 1.0f
+                this.ocelotFrontLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI + 0.3f)
+                        * 1.0f
                         * p_78087_2_;
-                this.ocelotFrontRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f
+                this.ocelotFrontRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f
                         * p_78087_2_;
-                this.ocelotTail2.rotateAngleX = 1.7278761f + 0.31415927f * MathHelper.cos(p_78087_1_) * p_78087_2_;
+                this.ocelotTail2.rotateAngleX = 1.7278761f
+                        + ((float) Math.PI / 10F) * MathHelper.cos(p_78087_1_) * p_78087_2_;
             } else {
                 this.ocelotBackLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
-                this.ocelotBackRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f
+                this.ocelotBackRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f
                         * p_78087_2_;
-                this.ocelotFrontLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + 3.1415927f) * 1.0f
+                this.ocelotFrontLeftLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f + (float) Math.PI) * 1.0f
                         * p_78087_2_;
                 this.ocelotFrontRightLeg.rotateAngleX = MathHelper.cos(p_78087_1_ * 0.6662f) * 1.0f * p_78087_2_;
                 if (this.field_78163_i == 1) {
-                    this.ocelotTail2.rotateAngleX = 1.7278761f + 0.7853982f * MathHelper.cos(p_78087_1_) * p_78087_2_;
+                    this.ocelotTail2.rotateAngleX = 1.7278761f
+                            + ((float) Math.PI / 4F) * MathHelper.cos(p_78087_1_) * p_78087_2_;
                 } else {
                     this.ocelotTail2.rotateAngleX = 1.7278761f + 0.47123894f * MathHelper.cos(p_78087_1_) * p_78087_2_;
                 }
@@ -163,18 +166,18 @@ public class ModelGuardianPanther extends ModelBase {
             ocelotTail2.rotationPointY -= 4.0f;
             final ModelRenderer ocelotTail3 = this.ocelotTail2;
             ocelotTail3.rotationPointZ += 2.0f;
-            this.ocelotTail.rotateAngleX = 1.5707964f;
-            this.ocelotTail2.rotateAngleX = 1.5707964f;
+            this.ocelotTail.rotateAngleX = ((float) Math.PI / 2F);
+            this.ocelotTail2.rotateAngleX = ((float) Math.PI / 2F);
             this.field_78163_i = 0;
         } else if (entityocelot.isSprinting()) {
             this.ocelotTail2.rotationPointY = this.ocelotTail.rotationPointY;
             final ModelRenderer ocelotTail4 = this.ocelotTail2;
             ocelotTail4.rotationPointZ += 2.0f;
-            this.ocelotTail.rotateAngleX = 1.5707964f;
-            this.ocelotTail2.rotateAngleX = 1.5707964f;
+            this.ocelotTail.rotateAngleX = ((float) Math.PI / 2F);
+            this.ocelotTail2.rotateAngleX = ((float) Math.PI / 2F);
             this.field_78163_i = 2;
         } else if (entityocelot.isSitting()) {
-            this.ocelotBody.rotateAngleX = 0.7853982f;
+            this.ocelotBody.rotateAngleX = ((float) Math.PI / 4F);
             final ModelRenderer ocelotBody2 = this.ocelotBody;
             ocelotBody2.rotationPointY -= 4.0f;
             final ModelRenderer ocelotBody3 = this.ocelotBody;
@@ -210,7 +213,7 @@ public class ModelGuardianPanther extends ModelBase {
             ocelotFrontLeftLeg5.rotationPointZ = n7;
             final ModelRenderer ocelotBackLeftLeg3 = this.ocelotBackLeftLeg;
             final ModelRenderer ocelotBackRightLeg3 = this.ocelotBackRightLeg;
-            final float n8 = -1.5707964f;
+            final float n8 = -((float) Math.PI / 2F);
             ocelotBackRightLeg3.rotateAngleX = n8;
             ocelotBackLeftLeg3.rotateAngleX = n8;
             final ModelRenderer ocelotBackLeftLeg4 = this.ocelotBackLeftLeg;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelInjector.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/model/ModelInjector.java
@@ -45,7 +45,7 @@ public class ModelInjector extends ModelBase {
         this.BowR1.setRotationPoint(2.5f, 1.0f, -8.0f);
         this.BowR1.setTextureSize(64, 32);
         this.BowR1.mirror = true;
-        this.setRotation(this.BowR1, 0.0f, 3.141593f, 0.0f);
+        this.setRotation(this.BowR1, 0.0f, (float) Math.PI, 0.0f);
         (this.BowL2 = new ModelRenderer(this, 0, 8)).addBox(0.0f, -1.0f, 0.0f, 3, 1, 1);
         this.BowL2.setRotationPoint(6.0f, 1.0f, -7.5f);
         this.BowL2.setTextureSize(64, 32);
@@ -84,8 +84,8 @@ public class ModelInjector extends ModelBase {
         this.BowR2.render(f5);
         this.Stock.render(f5);
         this.Grip.render(f5);
-        GL11.glDisable(3553);
-        GL11.glDisable(2896);
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GL11.glDisable(GL11.GL_LIGHTING);
         final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawing(3);
         tessellator.setColorOpaque_I(0);
@@ -102,8 +102,8 @@ public class ModelInjector extends ModelBase {
                 this.BowL2.rotationPointY - 0.9375,
                 this.BowL2.rotationPointZ + 6.8125 + f3 * 0.125);
         tessellator.draw();
-        GL11.glEnable(2896);
-        GL11.glEnable(3553);
+        GL11.glEnable(GL11.GL_LIGHTING);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
         this.Thingy.setRotationPoint(
                 (this.BowR2.rotationPointX + this.BowL2.rotationPointX) / 2.0f,
                 0.0f,
@@ -121,9 +121,9 @@ public class ModelInjector extends ModelBase {
             final float f5, final Entity ent) {
         super.setRotationAngles(f, f1, f2, f3, f4, f5, ent);
         this.BowL1.rotateAngleY = -f;
-        this.BowR1.rotateAngleY = f + 3.1415927f;
+        this.BowR1.rotateAngleY = f + (float) Math.PI;
         this.BowL2.rotateAngleY = -0.34906238f - f1;
         this.BowR2.rotateAngleY = 3.490655f + f1;
-        this.Drum.rotateAngleZ = f2 * 2.0f * 3.1415927f / 180.0f;
+        this.Drum.rotateAngleZ = f2 * 2.0f * (float) Math.PI / 180.0f;
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/ItemJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/ItemJarTHRenderer.java
@@ -49,20 +49,20 @@ public class ItemJarTHRenderer implements IItemRenderer {
             if (item.hasTagCompound() && item.stackTagCompound.getBoolean("isSoul")) {
                 final long nt = System.nanoTime();
                 UtilsFX.bindTexture("thaumichorizons", ItemJarTHRenderer.tx3);
-                GL11.glEnable(3042);
-                GL11.glAlphaFunc(516, 0.003921569f);
-                GL11.glDisable(2929);
-                GL11.glDisable(2884);
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
+                GL11.glDisable(GL11.GL_CULL_FACE);
                 GL11.glPushMatrix();
                 GL11.glTranslated(0.0, 0.4, 0.0);
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, 771);
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 UtilsFX.renderAnimatedQuad(0.3f, 0.9f, 16, (int) (nt / 40000000L % 16L), 0.0f, 16777215);
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
                 GL11.glPopMatrix();
-                GL11.glEnable(2884);
-                GL11.glEnable(2929);
-                GL11.glDisable(3042);
+                GL11.glEnable(GL11.GL_CULL_FACE);
+                GL11.glEnable(GL11.GL_DEPTH_TEST);
+                GL11.glDisable(GL11.GL_BLEND);
             } else if (item.hasTagCompound()) {
                 final TileSoulJar th = new TileSoulJar();
                 GL11.glPushMatrix();
@@ -71,21 +71,21 @@ public class ItemJarTHRenderer implements IItemRenderer {
                 final EntityLivingBase viewer = Minecraft.getMinecraft().thePlayer;
                 th.entity = EntityList.createEntityFromNBT(item.getTagCompound(), viewer.worldObj);
                 TileEntityRendererDispatcher.instance.renderTileEntityAt(th, 0.0, 0.0, 0.0, 0.0f);
-                GL11.glBlendFunc(770, 771);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 Minecraft.getMinecraft().entityRenderer.disableLightmap(0.0);
                 GL11.glPopMatrix();
             }
             GL11.glPushMatrix();
             GL11.glTranslatef(0.0f, 0.5f, 0.0f);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
             Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
             final RenderBlocks rb = (RenderBlocks) data[0];
             rb.useInventoryTint = true;
             rb.renderBlockAsItem(ConfigBlocks.blockJar, 0, 1.0f);
             GL11.glPopMatrix();
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
         }
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileCloudRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileCloudRender.java
@@ -51,7 +51,7 @@ public class TileCloudRender extends TileEntitySpecialRenderer {
             return;
         }
         final float f1 = 1.0f;
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         if (f1 > 0.0f) {
             final Tessellator tessellator = Tessellator.instance;
             final BiomeGenBase biomegenbase = tco.getWorldObj().getBiomeGenForCoords(tco.xCoord, tco.zCoord);
@@ -62,11 +62,11 @@ public class TileCloudRender extends TileEntitySpecialRenderer {
             } else {
                 this.bindTexture(TileCloudRender.locationSnowPng);
             }
-            GL11.glTexParameterf(3553, 10242, 10497.0f);
-            GL11.glTexParameterf(3553, 10243, 10497.0f);
-            GL11.glDisable(2896);
-            GL11.glDisable(2884);
-            GL11.glDisable(3042);
+            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0f);
+            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0f);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            GL11.glDisable(GL11.GL_CULL_FACE);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glDepthMask(true);
             OpenGlHelper.glBlendFunc(770, 1, 1, 0);
             final float f2 = tco.getWorldObj().getTotalWorldTime() + p_147500_8_ + tco.xCoord + 16 * tco.zCoord;
@@ -130,8 +130,8 @@ public class TileCloudRender extends TileEntitySpecialRenderer {
             tessellator.addVertexWithUV(p_147500_2_ + d4, p_147500_4_, p_147500_6_ + d5, d13, d15);
             tessellator.addVertexWithUV(p_147500_2_ + d4, p_147500_4_ - d12, p_147500_6_ + d5, d13, d16);
             tessellator.draw();
-            GL11.glEnable(2896);
-            GL11.glEnable(3553);
+            GL11.glEnable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
             GL11.glDepthMask(true);
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEssentiaDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEssentiaDynamoRender.java
@@ -53,9 +53,9 @@ public class TileEssentiaDynamoRender extends TileEntitySpecialRenderer {
         }
         if (tco.rise >= 0.3f && tco.ticksProvided > 0) {
             GL11.glPushMatrix();
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 1);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
             final long nt = System.nanoTime();
             UtilsFX.bindTexture(TileEssentiaDynamoRender.tx3);
             final int frames = UtilsFX.getTextureAnimationSize(TileEssentiaDynamoRender.tx3);
@@ -71,8 +71,8 @@ public class TileEssentiaDynamoRender extends TileEntitySpecialRenderer {
                     i,
                     f,
                     tco.essentia.getColor());
-            GL11.glDisable(3042);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             GL11.glPopMatrix();
         }
         GL11.glPushMatrix();

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -18,6 +18,7 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
 
@@ -80,7 +81,7 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
                     && tco.getAspectsBase().getAspects()[0] != null) {
                 final double offset = 6.283185307179586 / tco.getAspectsBase().size();
                 int which = 0;
-                GL11.glAlphaFunc(516, 0.003921569f);
+                GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
                 GL11.glDepthMask(false);
                 for (final Aspect asp2 : tco.getAspectsBase().getAspects()) {
                     if (asp2 == null) {
@@ -88,8 +89,8 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
                     }
                     final Color colo = new Color(asp2.getColor());
                     GL11.glPushMatrix();
-                    GL11.glEnable(3042);
-                    GL11.glBlendFunc(770, 771);
+                    GL11.glEnable(GL11.GL_BLEND);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                     final double radian = Math.toRadians(tco.rotation);
                     final double dist = 0.4 + 0.1 * Math.cos(radian);
                     UtilsFX.renderFacingStrip(
@@ -104,12 +105,12 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
                             (int) tco.rotation % frames,
                             f,
                             colo.getRGB());
-                    GL11.glDisable(3042);
+                    GL11.glDisable(GL11.GL_BLEND);
                     GL11.glPopMatrix();
                     ++which;
                 }
                 GL11.glDepthMask(true);
-                GL11.glAlphaFunc(516, 0.1f);
+                GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             }
             if (tco != null && tco.drainEntity != null && tco.drainCollision != null) {
                 final Entity drainEntity = tco.drainEntity;
@@ -128,11 +129,11 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
                 final Vec3 vec3 = Vec3.createVectorHelper(-0.1, -0.1, 0.5);
                 vec3.rotateAroundX(
                         -(drainEntity.prevRotationPitch
-                                + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * 3.141593f
+                                + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * (float) Math.PI
                                 / 180.0f);
                 vec3.rotateAroundY(
                         -(drainEntity.prevRotationYaw + (drainEntity.rotationYaw - drainEntity.prevRotationYaw) * f)
-                                * 3.141593f
+                                * (float) Math.PI
                                 / 180.0f);
                 vec3.rotateAroundY(-f2 * 0.01f);
                 vec3.rotateAroundX(-f2 * 0.015f);
@@ -155,8 +156,8 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
                         Math.min(iiud, 10) / 10.0f);
                 GL11.glPopMatrix();
             }
-            GL11.glDisable(3042);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         } catch (Exception e) {
             System.out.println(e.getMessage());
         } finally {
@@ -174,10 +175,10 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
         final float g = c.getGreen() / 220.0f;
         final float b = c.getBlue() / 220.0f;
         GL11.glPushMatrix();
-        GL11.glEnable(2977);
-        GL11.glEnable(3042);
-        GL11.glEnable(32826);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_NORMALIZE);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glTranslatef(x + 0.5f, (float) (y - 0.15f + 0.10000000149011612 * Math.sin(Math.toRadians(a1))), z + 0.5f);
         GL11.glRotatef(a1, 0.0f, 1.0f, 0.0f);
         GL11.glRotatef(a2, 1.0f, 0.0f, 0.0f);
@@ -192,8 +193,8 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
         GL11.glColor4f(r, g, b, 1.0f);
         this.model.render();
         GL11.glScalef(1.0f, 1.0f, 1.0f);
-        GL11.glDisable(32826);
-        GL11.glDisable(3042);
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileInspiratronRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileInspiratronRender.java
@@ -10,6 +10,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.client.renderer.model.ModelInspiratron;
 import com.kentington.thaumichorizons.common.tiles.TileInspiratron;
@@ -34,17 +35,17 @@ public class TileInspiratronRender extends TileEntitySpecialRenderer {
     public void renderTileEntityAt(final TileEntity tile, final double x, final double y, final double z,
             final float f) {
         GL11.glPushMatrix();
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glTranslatef((float) x + 0.5f, (float) y, (float) z + 0.5f);
         GL11.glRotatef(180.0f, 1.0f, 0.0f, 0.0f);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glPushMatrix();
         GL11.glTranslatef(0.0f, -0.125f, 0.0f);
         this.renderBrain((TileInspiratron) tile, x, y, z, f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glTranslatef(0.0f, -1.5f, 0.0f);
         UtilsFX.bindTexture("thaumichorizons", TileInspiratronRender.tx1);
         this.inspiratron.render(null, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0625f);
@@ -57,9 +58,9 @@ public class TileInspiratronRender extends TileEntitySpecialRenderer {
         GL11.glTranslatef(0.0f, -0.8f + bob, 0.0f);
         if (te != null) {
             float f2;
-            for (f2 = te.rota - te.rotb; f2 < -3.141593f; f2 += 6.283185f) {}
+            for (f2 = te.rota - te.rotb; f2 < -(float) Math.PI; f2 += ((float) Math.PI * 2F)) {}
             final float f3 = te.rotb + f2 * f;
-            GL11.glRotatef(f3 * 180.0f / 3.141593f, 0.0f, 1.0f, 0.0f);
+            GL11.glRotatef(f3 * 180.0f / (float) Math.PI, 0.0f, 1.0f, 0.0f);
         }
         GL11.glRotatef(-90.0f, 0.0f, 1.0f, 0.0f);
         UtilsFX.bindTexture("thaumichorizons", "textures/models/brain.png");

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileJarTHRenderer.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileJarTHRenderer.java
@@ -37,13 +37,13 @@ public class TileJarTHRenderer extends TileEntitySpecialRenderer {
         if (th.jarTag != null && th.jarTag.getBoolean("isSoul")) {
             final long nt = System.nanoTime();
             UtilsFX.bindTexture("thaumichorizons", TileJarTHRenderer.tx3);
-            GL11.glEnable(3042);
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glDisable(2929);
-            GL11.glDisable(2884);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
+            GL11.glDisable(GL11.GL_CULL_FACE);
             GL11.glPushMatrix();
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             UtilsFX.renderFacingQuad(
                     tile.xCoord + 0.5,
                     tile.yCoord + 0.4,
@@ -55,15 +55,15 @@ public class TileJarTHRenderer extends TileEntitySpecialRenderer {
                     (int) (nt / 40000000L % 16L),
                     f,
                     16777215);
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glPopMatrix();
-            GL11.glEnable(2884);
-            GL11.glEnable(2929);
-            GL11.glDisable(3042);
+            GL11.glEnable(GL11.GL_CULL_FACE);
+            GL11.glEnable(GL11.GL_DEPTH_TEST);
+            GL11.glDisable(GL11.GL_BLEND);
             return;
         }
         GL11.glPushMatrix();
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glTranslatef((float) x + 0.5f, (float) y + 0.01f, (float) z + 0.5f);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         this.bindTexture(th.getTexture());
@@ -77,7 +77,7 @@ public class TileJarTHRenderer extends TileEntitySpecialRenderer {
                 render.doRender(th.entity, 0.0, 0.0, 0.0, 0.0f, f);
             }
         }
-        GL11.glEnable(2884);
+        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileNodeMonitorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileNodeMonitorRender.java
@@ -11,6 +11,7 @@ import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.tiles.TileNodeMonitor;
 
@@ -69,10 +70,10 @@ public class TileNodeMonitorRender extends TileEntitySpecialRenderer {
         }
         UtilsFX.bindTexture("thaumichorizons", TileNodeMonitorRender.tx1);
         this.model.renderAll();
-        GL11.glEnable(2977);
-        GL11.glEnable(3042);
-        GL11.glEnable(32826);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_NORMALIZE);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         if (tco.switchy) {
             UtilsFX.bindTexture("thaumichorizons", TileNodeMonitorRender.tx3);
         } else {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TilePortalTHRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TilePortalTHRender.java
@@ -39,8 +39,8 @@ public class TilePortalTHRender extends TileEntitySpecialRenderer {
         UtilsFX.bindTexture(TilePortalTHRender.portaltex);
         GL11.glPushMatrix();
         GL11.glDepthMask(false);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glColor4f(1.0f, 0.0f, 1.0f, 1.0f);
         if (Minecraft.getMinecraft().renderViewEntity instanceof final EntityPlayer player) {
             final Tessellator tessellator = Tessellator.instance;
@@ -91,7 +91,7 @@ public class TilePortalTHRender extends TileEntitySpecialRenderer {
                     .addVertexWithUV(px + v4.xCoord * scale, py + v4.yCoord * scaley, pz + v4.zCoord * scale, f2, f4);
             tessellator.draw();
         }
-        GL11.glDisable(3042);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glDepthMask(true);
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileRecombinatorRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileRecombinatorRender.java
@@ -42,8 +42,8 @@ public class TileRecombinatorRender extends TileEntitySpecialRenderer {
             final int frames = UtilsFX.getTextureAnimationSize(TileRecombinatorRender.tx2);
             final int i = (int) ((nt / 40000000L + x) % frames);
             UtilsFX.bindTexture("thaumcraft", TileRecombinatorRender.tx2);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glScalef(1.0f, 1.0f, 1.0f);
             GL11.glPushMatrix();
             UtilsFX.renderFacingQuad(
@@ -73,7 +73,7 @@ public class TileRecombinatorRender extends TileEntitySpecialRenderer {
                         0.1f,
                         3);
             }
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
         }
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulBeaconRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulBeaconRender.java
@@ -36,15 +36,15 @@ public class TileSoulBeaconRender extends TileEntitySpecialRenderer {
             return;
         }
         final float f1 = tco.func_146002_i();
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         if (f1 > 0.0f) {
             final Tessellator tessellator = Tessellator.instance;
             this.bindTexture(TileSoulBeaconRender.field_147523_b);
-            GL11.glTexParameterf(3553, 10242, 10497.0f);
-            GL11.glTexParameterf(3553, 10243, 10497.0f);
-            GL11.glDisable(2896);
-            GL11.glDisable(2884);
-            GL11.glDisable(3042);
+            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0f);
+            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0f);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            GL11.glDisable(GL11.GL_CULL_FACE);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glDepthMask(true);
             OpenGlHelper.glBlendFunc(770, 1, 1, 0);
             final float f2 = tco.getWorldObj().getTotalWorldTime() + p_147500_8_;
@@ -84,7 +84,7 @@ public class TileSoulBeaconRender extends TileEntitySpecialRenderer {
             tessellator.addVertexWithUV(p_147500_2_ + d5, p_147500_4_, p_147500_6_ + d6, d14, d16);
             tessellator.addVertexWithUV(p_147500_2_ + d5, p_147500_4_ + d13, p_147500_6_ + d6, d14, d17);
             tessellator.draw();
-            GL11.glEnable(3042);
+            GL11.glEnable(GL11.GL_BLEND);
             OpenGlHelper.glBlendFunc(770, 771, 1, 0);
             GL11.glDepthMask(false);
             tessellator.startDrawingQuads();
@@ -119,8 +119,8 @@ public class TileSoulBeaconRender extends TileEntitySpecialRenderer {
             tessellator.addVertexWithUV(p_147500_2_ + d18, p_147500_4_, p_147500_6_ + d19, d27, d29);
             tessellator.addVertexWithUV(p_147500_2_ + d18, p_147500_4_ + d26, p_147500_6_ + d19, d27, d30);
             tessellator.draw();
-            GL11.glEnable(2896);
-            GL11.glEnable(3553);
+            GL11.glEnable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
             GL11.glDepthMask(true);
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulforgeRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileSoulforgeRender.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.client.renderer.model.ModelSoulforge;
 import com.kentington.thaumichorizons.common.tiles.TileSoulforge;
@@ -31,16 +32,16 @@ public class TileSoulforgeRender extends TileEntitySpecialRenderer {
     public void renderTileEntityAt(final TileEntity tile, final double x, final double y, final double z,
             final float f) {
         GL11.glPushMatrix();
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glTranslatef((float) x + 0.5f, (float) y, (float) z + 0.5f);
         GL11.glRotatef(180.0f, 1.0f, 0.0f, 0.0f);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glPushMatrix();
         GL11.glTranslatef(0.0f, -0.25f, 0.0f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         this.renderBrains((TileSoulforge) tile, x, y, z, f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
         GL11.glTranslatef(0.0f, -1.5f, 0.0f);
         UtilsFX.bindTexture("thaumichorizons", TileSoulforgeRender.tx1);
@@ -51,8 +52,8 @@ public class TileSoulforgeRender extends TileEntitySpecialRenderer {
             final int frames = UtilsFX.getTextureAnimationSize(TileSoulforgeRender.tx2);
             final int i = (int) ((nt / 40000000L + x) % frames);
             UtilsFX.bindTexture("thaumcraft", TileSoulforgeRender.tx2);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glScalef(1.0f, 1.0f, 1.0f);
             GL11.glPushMatrix();
             UtilsFX.renderFacingQuad(
@@ -106,7 +107,7 @@ public class TileSoulforgeRender extends TileEntitySpecialRenderer {
                     f,
                     16777215);
             GL11.glPopMatrix();
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
         }
         if (((TileSoulforge) tile).souls > 0) {
             final double offset = 6.283185307179586 / ((TileSoulforge) tile).souls;
@@ -114,14 +115,14 @@ public class TileSoulforgeRender extends TileEntitySpecialRenderer {
             final double radian = Math.toRadians((int) (nt / 40000000L % 360L));
             final double dist = 0.1 + 0.1 * Math.cos(radian);
             UtilsFX.bindTexture("thaumichorizons", TileSoulforgeRender.tx3);
-            GL11.glEnable(3042);
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glDisable(2929);
-            GL11.glDisable(2884);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
+            GL11.glDisable(GL11.GL_CULL_FACE);
             for (int which = 0; which < ((TileSoulforge) tile).souls; ++which) {
                 GL11.glPushMatrix();
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, 771);
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 UtilsFX.renderFacingQuad(
                         tile.xCoord + 0.5 + dist * Math.sin(2.0 * radian + offset * which),
                         tile.yCoord + 0.85,
@@ -133,12 +134,12 @@ public class TileSoulforgeRender extends TileEntitySpecialRenderer {
                         (int) (nt / 40000000L % frames),
                         f,
                         16777215);
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
                 GL11.glPopMatrix();
             }
-            GL11.glEnable(2884);
-            GL11.glEnable(2929);
-            GL11.glDisable(3042);
+            GL11.glEnable(GL11.GL_CULL_FACE);
+            GL11.glEnable(GL11.GL_DEPTH_TEST);
+            GL11.glDisable(GL11.GL_BLEND);
         }
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatMatrixRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatMatrixRender.java
@@ -50,12 +50,12 @@ public class TileVatMatrixRender extends TileEntitySpecialRenderer {
         final float f2 = 0.9f;
         final float f3 = 0.0f;
         final Random random = new Random(245L);
-        GL11.glDisable(3553);
-        GL11.glShadeModel(7425);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
-        GL11.glDisable(3008);
-        GL11.glEnable(2884);
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GL11.glShadeModel(GL11.GL_SMOOTH);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+        GL11.glDisable(GL11.GL_ALPHA_TEST);
+        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glDepthMask(false);
         GL11.glPushMatrix();
         for (int i = 0; i < q; ++i) {
@@ -81,14 +81,14 @@ public class TileVatMatrixRender extends TileEntitySpecialRenderer {
         }
         GL11.glPopMatrix();
         GL11.glDepthMask(true);
-        GL11.glDisable(2884);
-        GL11.glDisable(3042);
-        GL11.glShadeModel(7424);
+        GL11.glDisable(GL11.GL_CULL_FACE);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glShadeModel(GL11.GL_FLAT);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-        GL11.glEnable(3553);
-        GL11.glEnable(3008);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        GL11.glEnable(GL11.GL_ALPHA_TEST);
         RenderHelper.enableStandardItemLighting();
-        GL11.glBlendFunc(770, 771);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glPopMatrix();
     }
 
@@ -151,9 +151,9 @@ public class TileVatMatrixRender extends TileEntitySpecialRenderer {
             }
         }
         GL11.glPushMatrix();
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 1);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
         for (int a = 0; a < 2; ++a) {
             for (int b4 = 0; b4 < 2; ++b4) {
                 for (int c = 0; c < 2; ++c) {
@@ -197,9 +197,9 @@ public class TileVatMatrixRender extends TileEntitySpecialRenderer {
                 }
             }
         }
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
-        GL11.glBlendFunc(770, 771);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glPopMatrix();
         GL11.glPopMatrix();
         if (vat != null && vat.mode == 2) {

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatRender.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.client.renderer.model.ModelVat;
 
@@ -27,7 +28,7 @@ public class TileVatRender extends TileEntitySpecialRenderer {
         GL11.glTranslatef((float) x + 0.5f, (float) y - 0.5f, (float) z + 0.5f);
         UtilsFX.bindTexture("thaumichorizons", this.tx1);
         TileVatRender.model.render(null, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0625f);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatSlaveRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVatSlaveRender.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.common.tiles.TileVat;
 
@@ -41,8 +42,8 @@ public class TileVatSlaveRender extends TileEntitySpecialRenderer {
                     final float n = 800 - tco.progress;
                     tco.getClass();
                     final float scale = n / 800.0f;
-                    GL11.glEnable(3042);
-                    GL11.glBlendFunc(770, 771);
+                    GL11.glEnable(GL11.GL_BLEND);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                     GL11.glColor4f(1.0f, 1.0f, 1.0f, scale);
                     final Entity p_147936_1_ = tco.getEntityContained();
                     final double d0 = p_147936_1_.lastTickPosX + (p_147936_1_.posX - p_147936_1_.lastTickPosX) * f;
@@ -62,7 +63,7 @@ public class TileVatSlaveRender extends TileEntitySpecialRenderer {
                     RenderManager.instance.renderEntitySimple(tco.getEntityContained(), f);
                 }
                 GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
             } else if (tco.mode == 3) {
                 GL11.glRotatef(180.0f, 0.0f, 0.0f, 1.0f);
                 GL11.glTranslatef(
@@ -98,7 +99,7 @@ public class TileVatSlaveRender extends TileEntitySpecialRenderer {
                         0.0f);
                 RenderManager.instance.renderEntitySimple(this.stack, f);
             }
-            GL11.glEnable(32826);
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVisDynamoRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVisDynamoRender.java
@@ -41,9 +41,9 @@ public class TileVisDynamoRender extends TileEntitySpecialRenderer {
         final TileVisDynamo tco = (TileVisDynamo) te;
         if (tco.rise >= 0.3f && tco.ticksProvided > 0) {
             GL11.glPushMatrix();
-            GL11.glAlphaFunc(516, 0.003921569f);
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 1);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
             final long nt = System.nanoTime();
             UtilsFX.bindTexture(TileVisDynamoRender.tx3);
             final int frames = UtilsFX.getTextureAnimationSize(TileVisDynamoRender.tx3);
@@ -59,8 +59,8 @@ public class TileVisDynamoRender extends TileEntitySpecialRenderer {
                     i,
                     f,
                     tco.color.getRGB());
-            GL11.glDisable(3042);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             GL11.glPopMatrix();
         }
         if (tco.drainEntity != null && tco.drainCollision != null) {
@@ -79,11 +79,11 @@ public class TileVisDynamoRender extends TileEntitySpecialRenderer {
                 final Vec3 vec3 = Vec3.createVectorHelper(-0.1, -0.1, 0.5);
                 vec3.rotateAroundX(
                         -(drainEntity.prevRotationPitch
-                                + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * 3.141593f
+                                + (drainEntity.rotationPitch - drainEntity.prevRotationPitch) * f) * (float) Math.PI
                                 / 180.0f);
                 vec3.rotateAroundY(
                         -(drainEntity.prevRotationYaw + (drainEntity.rotationYaw - drainEntity.prevRotationYaw) * f)
-                                * 3.141593f
+                                * (float) Math.PI
                                 / 180.0f);
                 vec3.rotateAroundY(-f2 * 0.01f);
                 vec3.rotateAroundX(-f2 * 0.015f);

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -73,16 +73,16 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
             }
             float alpha = (float) ((viewDistance - distance) / viewDistance);
             GL11.glPushMatrix();
-            GL11.glAlphaFunc(516, 0.003921569f);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
             GL11.glDepthMask(false);
             if (depthIgnore) {
-                GL11.glDisable(2929);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
             }
-            GL11.glDisable(2884);
+            GL11.glDisable(GL11.GL_CULL_FACE);
             final long time = nt / 5000000L;
             final float bscale = 0.25f;
             GL11.glPushMatrix();
-            final float rad = 6.283186f;
+            final float rad = ((float) Math.PI * 2F);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, alpha);
             final int i = (int) ((nt / 40000000L + x) % frames);
             int count = 0;
@@ -99,8 +99,8 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                 }
                 average += aspects.getAmount(aspect);
                 GL11.glPushMatrix();
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, aspect.getBlend());
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, aspect.getBlend());
                 scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                 scale = 0.4f;
                 scale *= size;
@@ -132,7 +132,7 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                             partialTicks,
                             aspect.getColor());
                 }
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
                 GL11.glPopMatrix();
                 ++count;
                 if (aspect.getBlend() == 771) {
@@ -141,8 +141,8 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
             }
             average /= aspects.size();
             GL11.glPushMatrix();
-            GL11.glEnable(3042);
-            GL11.glBlendFunc(770, 771);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glColor4f(1.0f, 0.0f, 1.0f, alpha);
             float corescale = 1.0f;
             if (timeOpen < 50 && !collapsing) {
@@ -176,7 +176,7 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                         partialTicks,
                         16777215);
             }
-            GL11.glDisable(3042);
+            GL11.glDisable(GL11.GL_BLEND);
             GL11.glPopMatrix();
             if (plane) {
                 for (Aspect aspect2 : aspects.getAspects()) {
@@ -188,8 +188,8 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                     }
                     average += aspects.getAmount(aspect2);
                     GL11.glPushMatrix();
-                    GL11.glEnable(3042);
-                    GL11.glBlendFunc(770, 771);
+                    GL11.glEnable(GL11.GL_BLEND);
+                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                     scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                     scale = 0.4f;
                     scale *= size;
@@ -206,7 +206,7 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                             i,
                             partialTicks,
                             aspect2.getColor());
-                    GL11.glDisable(3042);
+                    GL11.glDisable(GL11.GL_BLEND);
                     GL11.glPopMatrix();
                     ++count;
                     if (aspect2.getBlend() == 771) {
@@ -215,12 +215,12 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                 }
             }
             GL11.glPopMatrix();
-            GL11.glEnable(2884);
+            GL11.glEnable(GL11.GL_CULL_FACE);
             if (depthIgnore) {
-                GL11.glEnable(2929);
+                GL11.glEnable(GL11.GL_DEPTH_TEST);
             }
             GL11.glDepthMask(true);
-            GL11.glAlphaFunc(516, 0.1f);
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexStabilizerRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexStabilizerRender.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.kentington.thaumichorizons.client.renderer.model.ModelVortexAttenuator;
 import com.kentington.thaumichorizons.common.tiles.TileVortexStabilizer;
@@ -27,7 +28,7 @@ public class TileVortexStabilizerRender extends TileEntitySpecialRenderer {
             final float p_147500_8_) {
         final TileVortexStabilizer te = (TileVortexStabilizer) p_147500_1_;
         GL11.glPushMatrix();
-        GL11.glDisable(2884);
+        GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glTranslatef((float) x + 0.5f, (float) y, (float) z + 0.5f);
         switch (te.blockMetadata) {
             case 0 -> {
@@ -60,9 +61,9 @@ public class TileVortexStabilizerRender extends TileEntitySpecialRenderer {
         }
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glPushMatrix();
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
-        GL11.glEnable(32826);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
         UtilsFX.bindTexture("thaumichorizons", TileVortexStabilizerRender.tx1);
         this.model.render(null, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0625f);

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBlastPhial.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBlastPhial.java
@@ -27,16 +27,16 @@ public class EntityBlastPhial extends EntityPotion {
                 p_i1790_2_.posZ,
                 p_i1790_2_.rotationYaw,
                 p_i1790_2_.rotationPitch);
-        this.posX -= MathHelper.cos(this.rotationYaw / 180.0f * 3.1415927f) * 0.16f;
+        this.posX -= MathHelper.cos(this.rotationYaw / 180.0f * (float) Math.PI) * 0.16f;
         this.posY -= 0.10000000149011612;
-        this.posZ -= MathHelper.sin(this.rotationYaw / 180.0f * 3.1415927f) * 0.16f;
+        this.posZ -= MathHelper.sin(this.rotationYaw / 180.0f * (float) Math.PI) * 0.16f;
         this.setPosition(this.posX, this.posY, this.posZ);
         this.yOffset = 0.0f;
-        this.motionX = -MathHelper.sin(this.rotationYaw / 180.0f * 3.1415927f)
-                * MathHelper.cos(this.rotationPitch / 180.0f * 3.1415927f);
-        this.motionZ = MathHelper.cos(this.rotationYaw / 180.0f * 3.1415927f)
-                * MathHelper.cos(this.rotationPitch / 180.0f * 3.1415927f);
-        this.motionY = -MathHelper.sin(this.rotationPitch / 180.0f * 3.1415927f);
+        this.motionX = -MathHelper.sin(this.rotationYaw / 180.0f * (float) Math.PI)
+                * MathHelper.cos(this.rotationPitch / 180.0f * (float) Math.PI);
+        this.motionZ = MathHelper.cos(this.rotationYaw / 180.0f * (float) Math.PI)
+                * MathHelper.cos(this.rotationPitch / 180.0f * (float) Math.PI);
+        this.motionY = -MathHelper.sin(this.rotationPitch / 180.0f * (float) Math.PI);
         this.setThrowableHeading(this.motionX, this.motionY, this.motionZ, power * 1.5f, 1.0f);
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBoatGreatwood.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBoatGreatwood.java
@@ -260,10 +260,10 @@ public class EntityBoatGreatwood extends EntityBoat {
             }
             if (this.riddenByEntity != null && this.riddenByEntity instanceof final EntityLivingBase entitylivingbase) {
                 final float f = this.riddenByEntity.rotationYaw + -entitylivingbase.moveStrafing * 90.0f;
-                this.motionX += -Math.sin(f * 3.1415927f / 180.0f) * this.speedMultiplier
+                this.motionX += -Math.sin(f * (float)Math.PI / 180.0f) * this.speedMultiplier
                         * entitylivingbase.moveForward
                         * 0.05000000074505806;
-                this.motionZ += Math.cos(f * 3.1415927f / 180.0f) * this.speedMultiplier
+                this.motionZ += Math.cos(f * (float)Math.PI / 180.0f) * this.speedMultiplier
                         * entitylivingbase.moveForward
                         * 0.05000000074505806;
             }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBoatThaumium.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityBoatThaumium.java
@@ -296,10 +296,10 @@ public class EntityBoatThaumium extends EntityBoat {
             }
             if (this.riddenByEntity != null && this.riddenByEntity instanceof final EntityLivingBase entitylivingbase) {
                 final float f = this.riddenByEntity.rotationYaw + -entitylivingbase.moveStrafing * 90.0f;
-                this.motionX += -Math.sin(f * 3.1415927f / 180.0f) * this.speedMultiplier
+                this.motionX += -Math.sin(f * (float)Math.PI / 180.0f) * this.speedMultiplier
                         * entitylivingbase.moveForward
                         * 0.05000000074505806;
-                this.motionZ += Math.cos(f * 3.1415927f / 180.0f) * this.speedMultiplier
+                this.motionZ += Math.cos(f * (float)Math.PI / 180.0f) * this.speedMultiplier
                         * entitylivingbase.moveForward
                         * 0.05000000074505806;
             }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntitySoul.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntitySoul.java
@@ -99,7 +99,7 @@ public class EntitySoul extends EntityFlying implements IMob {
                 this.waypointZ = this.posZ;
             }
         }
-        final float n = -(float) Math.atan2(this.motionX, this.motionZ) * 180.0f / 3.141593f;
+        final float n = -(float) Math.atan2(this.motionX, this.motionZ) * 180.0f / (float) Math.PI;
         this.rotationYaw = n;
         this.renderYawOffset = n;
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntitySyringe.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntitySyringe.java
@@ -133,16 +133,16 @@ public class EntitySyringe extends Entity implements IProjectile, IEntityAdditio
                 p_i1756_2_.posZ,
                 p_i1756_2_.rotationYaw,
                 p_i1756_2_.rotationPitch);
-        this.posX -= MathHelper.cos(this.rotationYaw / 180.0f * 3.1415927f) * 0.16f;
+        this.posX -= MathHelper.cos(this.rotationYaw / 180.0f * (float) Math.PI) * 0.16f;
         this.posY -= 0.10000000149011612;
-        this.posZ -= MathHelper.sin(this.rotationYaw / 180.0f * 3.1415927f) * 0.16f;
+        this.posZ -= MathHelper.sin(this.rotationYaw / 180.0f * (float) Math.PI) * 0.16f;
         this.setPosition(this.posX, this.posY, this.posZ);
         this.yOffset = 0.0f;
-        this.motionX = -MathHelper.sin(this.rotationYaw / 180.0f * 3.1415927f)
-                * MathHelper.cos(this.rotationPitch / 180.0f * 3.1415927f);
-        this.motionZ = MathHelper.cos(this.rotationYaw / 180.0f * 3.1415927f)
-                * MathHelper.cos(this.rotationPitch / 180.0f * 3.1415927f);
-        this.motionY = -MathHelper.sin(this.rotationPitch / 180.0f * 3.1415927f);
+        this.motionX = -MathHelper.sin(this.rotationYaw / 180.0f * (float) Math.PI)
+                * MathHelper.cos(this.rotationPitch / 180.0f * (float) Math.PI);
+        this.motionZ = MathHelper.cos(this.rotationYaw / 180.0f * (float) Math.PI)
+                * MathHelper.cos(this.rotationPitch / 180.0f * (float) Math.PI);
+        this.motionY = -MathHelper.sin(this.rotationPitch / 180.0f * (float) Math.PI);
         this.setThrowableHeading(this.motionX, this.motionY, this.motionZ, p_i1756_3_ * 1.5f, 1.0f);
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemBoatGreatwood.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemBoatGreatwood.java
@@ -44,8 +44,8 @@ public class ItemBoatGreatwood extends ItemBoat {
         final double d2 = p_77659_3_.prevPosY + (p_77659_3_.posY - p_77659_3_.prevPosY) * f + 1.62 - p_77659_3_.yOffset;
         final double d3 = p_77659_3_.prevPosZ + (p_77659_3_.posZ - p_77659_3_.prevPosZ) * f;
         final Vec3 vec3 = Vec3.createVectorHelper(d0, d2, d3);
-        final float f4 = MathHelper.cos(-f3 * 0.017453292f - 3.1415927f);
-        final float f5 = MathHelper.sin(-f3 * 0.017453292f - 3.1415927f);
+        final float f4 = MathHelper.cos(-f3 * 0.017453292f - (float) Math.PI);
+        final float f5 = MathHelper.sin(-f3 * 0.017453292f - (float) Math.PI);
         final float f6 = -MathHelper.cos(-f2 * 0.017453292f);
         final float f7 = MathHelper.sin(-f2 * 0.017453292f);
         final float f8 = f5 * f6;

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemBoatThaumium.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemBoatThaumium.java
@@ -44,8 +44,8 @@ public class ItemBoatThaumium extends ItemBoat {
         final double d2 = p_77659_3_.prevPosY + (p_77659_3_.posY - p_77659_3_.prevPosY) * f + 1.62 - p_77659_3_.yOffset;
         final double d3 = p_77659_3_.prevPosZ + (p_77659_3_.posZ - p_77659_3_.prevPosZ) * f;
         final Vec3 vec3 = Vec3.createVectorHelper(d0, d2, d3);
-        final float f4 = MathHelper.cos(-f3 * 0.017453292f - 3.1415927f);
-        final float f5 = MathHelper.sin(-f3 * 0.017453292f - 3.1415927f);
+        final float f4 = MathHelper.cos(-f3 * 0.017453292f - (float) Math.PI);
+        final float f5 = MathHelper.sin(-f3 * 0.017453292f - (float) Math.PI);
         final float f6 = -MathHelper.cos(-f2 * 0.017453292f);
         final float f7 = MathHelper.sin(-f2 * 0.017453292f);
         final float f8 = f5 * f6;

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensAir.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensAir.java
@@ -104,9 +104,9 @@ public class ItemLensAir extends Item implements ILens {
                 horiz /= hScale;
                 vert = vert / hScale / var7 * var6;
                 GL11.glPushMatrix();
-                GL11.glEnable(3042);
-                GL11.glBlendFunc(770, 771);
-                GL11.glAlphaFunc(518, 0.005f);
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glAlphaFunc(GL11.GL_GEQUAL, 0.005f);
                 final float minEnt = Math.min(ent.width, ent.height);
                 double size = minEnt * (minScreen / scale);
                 final double xCenter = var6 * (1.0 + horiz) / 2.0;
@@ -157,7 +157,7 @@ public class ItemLensAir extends Item implements ILens {
                     GL11.glPopMatrix();
                     GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
                 }
-                GL11.glDisable(3042);
+                GL11.glDisable(GL11.GL_BLEND);
                 GL11.glPopMatrix();
             }
         }

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
@@ -296,9 +296,9 @@ public class ItemLensOrderEntropy extends Item implements ILens {
 
     public void drawAspectTag(final Aspect aspect, final int amount, final int x, final int y, final int sw) {
         GL11.glPushMatrix();
-        GL11.glAlphaFunc(516, 0.003921569f);
-        GL11.glEnable(3042);
-        GL11.glBlendFunc(770, 771);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         final Minecraft mc = Minecraft.getMinecraft();
         final Color color = new Color(aspect.getColor());
         mc.renderEngine.bindTexture(aspect.getImage());
@@ -317,8 +317,8 @@ public class ItemLensOrderEntropy extends Item implements ILens {
         final String am = myFormatter.format(amount);
         mc.fontRenderer.drawString(am, 24 + x * 2, 32 - mc.fontRenderer.FONT_HEIGHT + y * 2, 16777215);
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-        GL11.glDisable(3042);
-        GL11.glAlphaFunc(516, 0.1f);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileInspiratron.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileInspiratron.java
@@ -53,20 +53,20 @@ public class TileInspiratron extends TileThaumcraft implements ISoulReceiver, IS
             } else {
                 this.field_40066_q += 0.01f;
             }
-            while (this.rota >= 3.141593f) {
-                this.rota -= 6.283185f;
+            while (this.rota >= (float) Math.PI) {
+                this.rota -= ((float) Math.PI * 2F);
             }
-            while (this.rota < -3.141593f) {
-                this.rota += 6.283185f;
+            while (this.rota < -(float) Math.PI) {
+                this.rota += ((float) Math.PI * 2F);
             }
-            while (this.field_40066_q >= 3.141593f) {
-                this.field_40066_q -= 6.283185f;
+            while (this.field_40066_q >= (float) Math.PI) {
+                this.field_40066_q -= ((float) Math.PI * 2F);
             }
-            while (this.field_40066_q < -3.141593f) {
-                this.field_40066_q += 6.283185f;
+            while (this.field_40066_q < -(float) Math.PI) {
+                this.field_40066_q += ((float) Math.PI * 2F);
             }
             float f4;
-            for (f4 = this.field_40066_q - this.rota; f4 < -3.141593f; f4 += 6.283185f) {}
+            for (f4 = this.field_40066_q - this.rota; f4 < -(float) Math.PI; f4 += ((float) Math.PI * 2F)) {}
             this.rota += f4 * 0.04f;
         }
     }


### PR DESCRIPTION
Just ran `./gradlew applyDecompilerCleanupToMain` to make the code more readable, it automatically replaces all random GL constants with the proper named variants, e.g. `3042` -> `GL11.GL_BLEND`