### PR TITLE
Fix Illumine Lens interaction with other sources of night vision.

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/lib/RenderEventHandler.java
@@ -36,6 +36,7 @@ import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.EntityBoatThaumium;
 import com.kentington.thaumichorizons.common.items.lenses.ILens;
 import com.kentington.thaumichorizons.common.items.lenses.ItemLensCase;
+import com.kentington.thaumichorizons.common.items.lenses.ItemLensFire;
 import com.kentington.thaumichorizons.common.items.lenses.LensManager;
 import com.kentington.thaumichorizons.common.lib.THKeyHandler;
 import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
@@ -97,8 +98,7 @@ public class RenderEventHandler {
             if (LensManager.nightVisionOffTime > 0L
                     && (goggles == null || !(goggles.getItem() instanceof IRevealer)
                             || goggles.stackTagCompound == null)
-                    && mc.thePlayer.getActivePotionEffect(Potion.nightVision) != null
-                    && mc.thePlayer.getActivePotionEffect(Potion.nightVision).getIsAmbient()) {
+                    && ItemLensFire.isEffectGrantedByLens(mc.thePlayer.getActivePotionEffect(Potion.nightVision))) {
                 mc.thePlayer.removePotionEffect(Potion.nightVision.id);
                 LensManager.nightVisionOffTime = 0L;
             }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20028.

Also fixes several other interactions of the Illumine lens with other sources of night vision.

Previously, the lens would aggressively override any other night vision effect by its own, leading to cases where it would remove other night vision effects (for example, granted by a potion) underwater, or when the lens or its helmet was removed.

With this fix, the lens only removes or extends night vision effects which were granted by the lens.

This incidentally fixes the flickering in the linked issue, which as @Ruling-0 identified was caused by the enchant applying a new night vision effect and the lens removing it, every tick.