### PR TITLE
Soul Beacon Event Handler Cleanup

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/ai/EntityAIHurtByTargetTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/ai/EntityAIHurtByTargetTH.java
@@ -31,7 +31,7 @@ public class EntityAIHurtByTargetTH extends EntityAITargetTH {
         this.field_142052_b = this.taskOwner.func_142015_aE();
         if (this.entityCallsForHelp) {
             final double d0 = this.getTargetDistance();
-            final List<EntityLiving> list = this.taskOwner.worldObj.getEntitiesWithinAABB(
+            final List<? extends EntityLiving> list = this.taskOwner.worldObj.getEntitiesWithinAABB(
                     this.taskOwner.getClass(),
                     AxisAlignedBB.getBoundingBox(
                             this.taskOwner.posX,

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketNoMoreItems.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/networking/PacketNoMoreItems.java
@@ -5,9 +5,9 @@
 package com.kentington.thaumichorizons.common.lib.networking;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.inventory.IInventory;
+import net.minecraft.client.entity.EntityClientPlayerMP;
 
-import baubles.api.BaublesApi;
+import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -19,12 +19,9 @@ public class PacketNoMoreItems implements IMessage, IMessageHandler<PacketNoMore
 
     @SideOnly(Side.CLIENT)
     public IMessage onMessage(final PacketNoMoreItems message, final MessageContext ctx) {
-        Minecraft.getMinecraft().thePlayer.inventory.clearInventory(null, -1);
-        final IInventory baubles = BaublesApi.getBaubles(Minecraft.getMinecraft().thePlayer);
-        baubles.setInventorySlotContents(0, null);
-        baubles.setInventorySlotContents(1, null);
-        baubles.setInventorySlotContents(2, null);
-        baubles.setInventorySlotContents(3, null);
+        EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
+        player.inventory.clearInventory(null, -1);
+        PlayerHandler.clearPlayerBaubles(player);
         return null;
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileTransductionAmplifier.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileTransductionAmplifier.java
@@ -231,7 +231,7 @@ public class TileTransductionAmplifier extends TileThaumcraft {
                 }
             }
             if (transducers > 1 && this.count % 50 == 0) {
-                final List<Entity> targets = (List<Entity>) this.worldObj.getEntitiesWithinAABB(
+                final List<EntityLivingBase> targets = this.worldObj.getEntitiesWithinAABB(
                         EntityLivingBase.class,
                         AxisAlignedBB.getBoundingBox(
                                 this.xCoord,
@@ -240,7 +240,7 @@ public class TileTransductionAmplifier extends TileThaumcraft {
                                 this.xCoord + 1,
                                 this.yCoord + 1,
                                 this.zCoord + 1).expand(10.0, 10.0, 10.0));
-                if (targets != null && targets.size() > 0) {
+                if (targets != null && !targets.isEmpty()) {
                     for (final Entity target : targets) {
                         PacketHandler.INSTANCE.sendToAllAround(
                                 new PacketFXBlockZap(

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
@@ -1048,7 +1048,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
     }
 
     private void inEvZap(final boolean all) {
-        final List<Entity> targets = (List<Entity>) this.worldObj.getEntitiesWithinAABB(
+        final List<EntityLivingBase> targets = this.worldObj.getEntitiesWithinAABB(
                 EntityLivingBase.class,
                 AxisAlignedBB.getBoundingBox(
                         this.xCoord,
@@ -1057,7 +1057,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                         this.xCoord + 1,
                         this.yCoord + 1,
                         this.zCoord + 1).expand(10.0, 10.0, 10.0));
-        if (targets != null && targets.size() > 0) {
+        if (targets != null && !targets.isEmpty()) {
             for (final Entity target : targets) {
                 thaumcraft.common.lib.network.PacketHandler.INSTANCE.sendToAllAround(
                         new PacketFXBlockZap(


### PR DESCRIPTION
Enable Generic Injection and fix associated problems caused by turning it on.

Fix wrong world reference being used for flux explosion with Soul Beacon reincarnation. Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20562
Refactor the rest of the damage event handler method to be cleaner and work with Baubles Expanded's slots instead of just the base 4.

