### PR TITLE
Synth Node now consumes the entire stack of essense instead of 1

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSyntheticNode.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSyntheticNode.java
@@ -440,6 +440,7 @@ public class TileSyntheticNode extends TileVisNode implements INode, IWandable {
         if (heldItem.stackSize == 0) return;
 
         if (heldItem.getItem() instanceof ItemWispEssence essence && essence == ConfigItems.itemWispEssence) {
+            if (essence.getAspects(heldItem) == null) return;
             var aspectList = essence.getAspects(heldItem).getAspects();
             if (aspectList == null || aspectList.length == 0) return;
             final Aspect asp = aspectList[0];


### PR DESCRIPTION
No longer need to change your binds to a key