### PR TITLE
Fix NPE in generatePocketPlane during async vortex creation

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.block.Block;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.entity.passive.EntityChicken;
@@ -33,6 +32,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.potion.Potion;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -79,7 +79,7 @@ public class PocketPlaneData {
     }
 
     public static void generatePocketPlane(final AspectList aspects, final PocketPlaneData data, final World world,
-                                           final int vortexX, final int vortexY, final int vortexZ, final int returnID) {
+            final int vortexX, final int vortexY, final int vortexZ, final int returnID) {
         if (!world.isRemote) {
             final int xCenter = 0;
             final int yCenter = 128;

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.entity.passive.EntityChicken;
@@ -78,7 +79,7 @@ public class PocketPlaneData {
     }
 
     public static void generatePocketPlane(final AspectList aspects, final PocketPlaneData data, final World world,
-            final int vortexX, final int vortexY, final int vortexZ, final int returnID) {
+                                           final int vortexX, final int vortexY, final int vortexZ, final int returnID) {
         if (!world.isRemote) {
             final int xCenter = 0;
             final int yCenter = 128;
@@ -111,7 +112,11 @@ public class PocketPlaneData {
                 }
             }
             world.setBlock(xCenter, yCenter + 1, zCenter, ThaumicHorizons.blockVortex);
-            final TileVortex vortex = (TileVortex) world.getTileEntity(xCenter, yCenter + 1, zCenter);
+            TileEntity te = world.getTileEntity(xCenter, yCenter + 1, zCenter);
+            if (!(te instanceof TileVortex)) {
+                te = new TileVortex();
+            }
+            final TileVortex vortex = (TileVortex) te;
             vortex.cheat = true;
             vortex.returnID = returnID;
             vortex.dimensionID = PocketPlaneData.planes.size();


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#24306
fixes a NullPointerException in `PocketPlaneData.generatePocketPlane`. On newer Java versions (Java 25), the TileEntity for the newly placed vortex block might not be immediately available in the world during the asynchronous generation process.

The fix adds a null/instance check and manually instantiates the TileEntity if it's missing, preventing the crash.