### PR TITLE
Fix keystone binding and wormhole pulling player back on exit

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
@@ -59,15 +59,20 @@ public class BlockSlot extends BlockContainer {
                 if (tco.portalOpen) {
                     tco.destroyPortal();
                 }
+                world.markBlockForUpdate(x, y, z);
+                return true;
             } else if (!tco.portalOpen && player.getHeldItem().getItem() instanceof ItemWandCasting) {
                 tco.makePortal(player);
+                world.markBlockForUpdate(x, y, z);
+                return true;
             }
         } else if (theItem != null && theItem.getItem() == ThaumicHorizons.itemKeystone
                 && theItem.stackTagCompound != null) {
-                    tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
-                    --theItem.stackSize;
-                }
-        world.markBlockForUpdate(x, y, z);
+            tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
+            --theItem.stackSize;
+            world.markBlockForUpdate(x, y, z);
+            return true;
+        }
         return false;
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
@@ -71,9 +71,13 @@ public class ItemKeystone extends Item {
             float hitX, float hitY, float hitZ) {
         if (stack.getTagCompound() == null && player.dimension == ThaumicHorizons.dimensionPocketId
                 && !world.isRemote) {
-            if (world.getTileEntity(x, y, z) instanceof TileVortex)
-                (stack.stackTagCompound = new NBTTagCompound()).setInteger("dimension", (z + 128) / 256);
-            return true;
+            final net.minecraft.tileentity.TileEntity te = world.getTileEntity(x, y, z);
+            if (te instanceof TileVortex) {
+                (stack.stackTagCompound = new NBTTagCompound()).setInteger("dimension", ((TileVortex) te).dimensionID);
+                player.inventory.markDirty();
+                return true;
+            }
+            return false;
         }
         return super.onItemUseFirst(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -175,7 +175,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                                 if (player.timeUntilPortal > 0) {
                                     player.timeUntilPortal = 10;
                                 } else if (player.dimension != ThaumicHorizons.dimensionPocketId) {
-                                    player.timeUntilPortal = 10;
+                                    player.timeUntilPortal = 200;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(
                                             player,
                                             ThaumicHorizons.dimensionPocketId,
@@ -183,7 +183,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                                                     mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId),
                                                     this.dimensionID));
                                 } else {
-                                    player.timeUntilPortal = 10;
+                                    player.timeUntilPortal = 200;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(
                                             player,
                                             this.returnID,


### PR DESCRIPTION
BlockSlot always returned false from onBlockActivated, so item use fired on top of block interaction. ItemKeystone bound to wrong plane when clicking non-vortex blocks, skipped client sync, and broke plane 0 due to dimension=0 being the blank sentinel. Wormhole teleport cooldown was 10 ticks - not enough to step off the vortex before it fired again, causing a ping-pong loop. Raised cooldown to 200 ticks.