### PR TITLE
Fix pocket plane keystone binding, portal bugs and world saving

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
@@ -117,7 +117,7 @@ public class BlockGatewayPortal extends Block {
             }
         }
         final TileEntity te = world.getTileEntity(slotX, slotY, slotZ);
-        if (te instanceof TileSlot) {
+        if (te instanceof TileSlot && ((TileSlot) te).portalOpen) {
             ((TileSlot) te).destroyPortal();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
@@ -69,11 +69,11 @@ public class BlockSlot extends BlockContainer {
             }
         } else if (theItem != null && theItem.getItem() == ThaumicHorizons.itemKeystone
                 && theItem.stackTagCompound != null) {
-            tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
-            --theItem.stackSize;
-            world.markBlockForUpdate(x, y, z);
-            return true;
-        }
+                    tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
+                    --theItem.stackSize;
+                    world.markBlockForUpdate(x, y, z);
+                    return true;
+                }
         return false;
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
@@ -32,6 +32,7 @@ public class BlockSlot extends BlockContainer {
 
     public void breakBlock(final World world, final int x, final int y, final int z, final Block block, final int md) {
         final TileSlot tco = (TileSlot) world.getTileEntity(x, y, z);
+        if (tco == null) return;
         if (tco.portalOpen) {
             tco.destroyPortal();
         }

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSlot.java
@@ -59,15 +59,20 @@ public class BlockSlot extends BlockContainer {
                 if (tco.portalOpen) {
                     tco.destroyPortal();
                 }
+                world.markBlockForUpdate(x, y, z);
+                return true;
             } else if (!tco.portalOpen && player.getHeldItem().getItem() instanceof ItemWandCasting) {
                 tco.makePortal(player);
+                world.markBlockForUpdate(x, y, z);
+                return true;
             }
         } else if (theItem != null && theItem.getItem() == ThaumicHorizons.itemKeystone
                 && theItem.stackTagCompound != null) {
-                    tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
-                    --theItem.stackSize;
-                }
-        world.markBlockForUpdate(x, y, z);
+            tco.insertKeystone(theItem.stackTagCompound.getInteger("dimension"));
+            --theItem.stackSize;
+            world.markBlockForUpdate(x, y, z);
+            return true;
+        }
         return false;
     }
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
@@ -50,8 +50,11 @@ public class ItemKeystone extends Item {
 
     public void addInformation(final ItemStack par1ItemStack, final EntityPlayer par2EntityPlayer, final List par3List,
             final boolean par4) {
-        if (par1ItemStack.getTagCompound() != null && par1ItemStack.getTagCompound().getInteger("dimension") != 0) {
-            par3List.add(PocketPlaneData.planes.get(par1ItemStack.getTagCompound().getInteger("dimension")).name);
+        if (par1ItemStack.getTagCompound() != null) {
+            final int dim = par1ItemStack.getTagCompound().getInteger("dimension");
+            if (dim >= 0 && dim < PocketPlaneData.planes.size()) {
+                par3List.add(PocketPlaneData.planes.get(dim).name);
+            }
         }
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemKeystone.java
@@ -71,9 +71,13 @@ public class ItemKeystone extends Item {
             float hitX, float hitY, float hitZ) {
         if (stack.getTagCompound() == null && player.dimension == ThaumicHorizons.dimensionPocketId
                 && !world.isRemote) {
-            if (world.getTileEntity(x, y, z) instanceof TileVortex)
-                (stack.stackTagCompound = new NBTTagCompound()).setInteger("dimension", (z + 128) / 256);
-            return true;
+            final net.minecraft.tileentity.TileEntity te = world.getTileEntity(x, y, z);
+            if (te instanceof TileVortex) {
+                (stack.stackTagCompound = new NBTTagCompound()).setInteger("dimension", ((TileVortex) te).dimensionID);
+                player.inventory.markDirty();
+                return true;
+            }
+            return false;
         }
         return super.onItemUseFirst(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/lib/PocketPlaneData.java
@@ -128,7 +128,7 @@ public class PocketPlaneData {
             data.portalD = new int[4];
             PocketPlaneData.planes.add(data);
             PocketPlaneData.positions.put(pocketPlaneMAXID, Vec3.createVectorHelper(vortexX, vortexY, vortexZ));
-            world.getChunkFromBlockCoords(vortexX, vortexZ).isModified = true;
+            world.getChunkFromBlockCoords(xCenter, zCenter).isModified = true;
             creatures = 0;
             ++pocketPlaneMAXID;
         }

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -175,7 +175,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                                 if (player.timeUntilPortal > 0) {
                                     player.timeUntilPortal = 10;
                                 } else if (player.dimension != ThaumicHorizons.dimensionPocketId) {
-                                    player.timeUntilPortal = 10;
+                                    player.timeUntilPortal = 200;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(
                                             player,
                                             ThaumicHorizons.dimensionPocketId,
@@ -183,7 +183,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                                                     mServer.worldServerForDimension(ThaumicHorizons.dimensionPocketId),
                                                     this.dimensionID));
                                 } else {
-                                    player.timeUntilPortal = 10;
+                                    player.timeUntilPortal = 200;
                                     player.mcServer.getConfigurationManager().transferPlayerToDimension(
                                             player,
                                             this.returnID,

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -321,7 +321,7 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                             this.xCoord,
                             this.yCoord,
                             this.zCoord,
-                            this.returnID))).run();
+                            this.returnID))).start();
         }
         this.markDirty();
     }


### PR DESCRIPTION
BlockSlot.onBlockActivated always returned false so item use fired on top of block interaction. ItemKeystone had return true outside the instanceof check, swallowing any right-click in pocket dimension with blank keystone. Coordinate formula for binding replaced with direct dimensionID read from TileVortex - fixes plane 0 appearing blank since dimension=0 is the unbound sentinel. Added inventory.markDirty() so client sees the bound keystone immediately.

Wormhole cooldown raised from 10 to 200 ticks - player lands directly on the pocket vortex after teleporting, 10 ticks was not enough to step off before it fired again causing a ping-pong loop.

Generation thread called .run() instead of .start(), blocking the server tick for the entire world generation. BlockSlot.breakBlock had no null check on tile entity. Gateway frame destruction could call destroyPortal multiple times on the same slot - guarded by portalOpen check. generatePocketPlane marked wrong chunk as modified using overworld coordinates in pocket dimension world, risking data loss before next autosave.