### PR TITLE
Clean up decompiler artifacts in TileVortex files

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
@@ -38,19 +37,18 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
         final float size = 10.0f;
         final double viewDistance = 64.0;
         final EntityLivingBase viewer = Minecraft.getMinecraft().renderViewEntity;
-        final boolean condition = true;
         final boolean depthIgnore = false;
         renderNode(
                 viewer,
                 viewDistance,
-                condition,
+                true,
                 depthIgnore,
                 size,
                 tile.xCoord,
                 tile.yCoord,
                 tile.zCoord,
                 partialTicks,
-                ((TileVortex) tile).aspects,
+                node.aspects,
                 node.count,
                 node.collapsing,
                 node.beams,
@@ -102,7 +100,6 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                 GL11.glPushMatrix();
                 GL11.glEnable(GL11.GL_BLEND);
                 GL11.glBlendFunc(GL11.GL_SRC_ALPHA, aspect.getBlend());
-                scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                 scale = 0.4f;
                 scale *= size;
                 final long periodNs = (5000L + 500L * count) * 5_000_000L;
@@ -192,7 +189,6 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                     GL11.glPushMatrix();
                     GL11.glEnable(GL11.GL_BLEND);
                     GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                     scale = 0.4f;
                     scale *= size;
                     final long periodNs2 = (5000L + 500L * count) * 5_000_000L;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
 
@@ -40,19 +39,18 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
         final float size = 10.0f;
         final double viewDistance = 64.0;
         final EntityLivingBase viewer = Minecraft.getMinecraft().renderViewEntity;
-        final boolean condition = true;
         final boolean depthIgnore = false;
         renderNode(
                 viewer,
                 viewDistance,
-                condition,
+                true,
                 depthIgnore,
                 size,
                 tile.xCoord,
                 tile.yCoord,
                 tile.zCoord,
                 partialTicks,
-                ((TileVortex) tile).aspects,
+                node.aspects,
                 node.count,
                 node.collapsing,
                 node.beams,
@@ -101,7 +99,6 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                 GL11.glPushMatrix();
                 GL11.glEnable(GL11.GL_BLEND);
                 GL11.glBlendFunc(GL11.GL_SRC_ALPHA, aspect.getBlend());
-                scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                 scale = 0.4f;
                 scale *= size;
                 angle = time % (5000 + 500 * count) / (5000.0f + 500 * count) * rad;
@@ -190,7 +187,6 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
                     GL11.glPushMatrix();
                     GL11.glEnable(GL11.GL_BLEND);
                     GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    scale = MathHelper.sin(viewer.ticksExisted / (14.0f - count)) * bscale + bscale * 2.0f;
                     scale = 0.4f;
                     scale *= size;
                     angle = time % (5000 + 500 * count) / (5000.0f + 500 * count) * rad;

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileVortexRender.java
@@ -35,16 +35,12 @@ public class TileVortexRender extends TileEntitySpecialRenderer {
         if (!(tile instanceof final TileVortex node) || !node.clientSynced) {
             return;
         }
-        final float size = 10.0f;
-        final double viewDistance = 64.0;
-        final EntityLivingBase viewer = Minecraft.getMinecraft().renderViewEntity;
-        final boolean depthIgnore = false;
         renderNode(
-                viewer,
-                viewDistance,
+                Minecraft.getMinecraft().renderViewEntity,
+                64.0,
                 true,
-                depthIgnore,
-                size,
+                false,
+                10.0f,
                 tile.xCoord,
                 tile.yCoord,
                 tile.zCoord,

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -51,7 +51,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class TileVortex extends TileThaumcraft implements IWandable, IAspectContainer {
 
-    final int MAX_COUNT = 2400;
+    private static final int MAX_COUNT = 2400;
     public int count;
     public int beams;
     public int dimensionID;
@@ -250,14 +250,15 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                 } else
             if (item.getEntityItem().getItem() == ThaumicHorizons.itemCrystalWand) {
                 final ItemStack theWand = new ItemStack(ThaumicHorizons.itemWandCastingDisposable);
-                ((ItemWandCasting) theWand.getItem()).setRod(theWand, ThaumicHorizons.ROD_CRYSTAL);
-                ((ItemWandCasting) theWand.getItem()).setCap(theWand, ThaumicHorizons.CAP_CRYSTAL);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.EARTH, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.AIR, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.FIRE, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.WATER, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.ORDER, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.ENTROPY, 25000);
+                final ItemWandCasting wand = (ItemWandCasting) theWand.getItem();
+                wand.setRod(theWand, ThaumicHorizons.ROD_CRYSTAL);
+                wand.setCap(theWand, ThaumicHorizons.CAP_CRYSTAL);
+                wand.storeVis(theWand, Aspect.EARTH, 25000);
+                wand.storeVis(theWand, Aspect.AIR, 25000);
+                wand.storeVis(theWand, Aspect.FIRE, 25000);
+                wand.storeVis(theWand, Aspect.WATER, 25000);
+                wand.storeVis(theWand, Aspect.ORDER, 25000);
+                wand.storeVis(theWand, Aspect.ENTROPY, 25000);
                 this.items.add(theWand);
                 item.setDead();
             } else
@@ -387,24 +388,25 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                             }
                         }
                     }
-                    final double var3 = (this.xCoord + 0.5 - eo.posX) / 15.0;
-                    final double var4 = (this.yCoord + 0.5 - eo.posY) / 15.0;
-                    final double var5 = (this.zCoord + 0.5 - eo.posZ) / 15.0;
-                    final double var6 = Math.sqrt(var3 * var3 + var4 * var4 + var5 * var5);
-                    double var7 = 1.0 - var6;
+                    final double dx = (this.xCoord + 0.5 - eo.posX) / 15.0;
+                    final double dy = (this.yCoord + 0.5 - eo.posY) / 15.0;
+                    final double dz = (this.zCoord + 0.5 - eo.posZ) / 15.0;
+                    final double dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    double var7 = 1.0 - dist;
                     final double modifier = 2.0 - this.beams / 3.0;
                     if (var7 <= 0.0) {
                         continue;
                     }
                     var7 *= var7;
-                    eo.motionX += var3 / var6 * var7 * 0.15 * modifier;
-                    eo.motionY += var4 / var6 * var7 * 0.25 * modifier;
-                    eo.motionZ += var5 / var6 * var7 * 0.15 * modifier;
+                    eo.motionX += dx / dist * var7 * 0.15 * modifier;
+                    eo.motionY += dy / dist * var7 * 0.25 * modifier;
+                    eo.motionZ += dz / dist * var7 * 0.15 * modifier;
                 }
             }
         }
         for (int i = 0; i < 3; ++i) {
-            if (!this.worldObj.isRemote && (this.beams <= 0 || this.worldObj.rand.nextInt(this.beams) == 0)) {
+            if (!this.worldObj.isRemote
+                    && (this.beams <= 0 || this.worldObj.rand.nextInt(Math.max(1, this.beams)) == 0)) {
                 int tx2 = this.xCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);
                 int ty2 = this.yCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);
                 int tz2 = this.zCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortex.java
@@ -49,7 +49,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class TileVortex extends TileThaumcraft implements IWandable, IAspectContainer {
 
-    final int MAX_COUNT = 2400;
+    private static final int MAX_COUNT = 2400;
     public int count;
     public int beams;
     public int dimensionID;
@@ -238,14 +238,15 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                 } else
             if (item.getEntityItem().getItem() == ThaumicHorizons.itemCrystalWand) {
                 final ItemStack theWand = new ItemStack(ThaumicHorizons.itemWandCastingDisposable);
-                ((ItemWandCasting) theWand.getItem()).setRod(theWand, ThaumicHorizons.ROD_CRYSTAL);
-                ((ItemWandCasting) theWand.getItem()).setCap(theWand, ThaumicHorizons.CAP_CRYSTAL);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.EARTH, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.AIR, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.FIRE, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.WATER, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.ORDER, 25000);
-                ((ItemWandCasting) theWand.getItem()).storeVis(theWand, Aspect.ENTROPY, 25000);
+                final ItemWandCasting wand = (ItemWandCasting) theWand.getItem();
+                wand.setRod(theWand, ThaumicHorizons.ROD_CRYSTAL);
+                wand.setCap(theWand, ThaumicHorizons.CAP_CRYSTAL);
+                wand.storeVis(theWand, Aspect.EARTH, 25000);
+                wand.storeVis(theWand, Aspect.AIR, 25000);
+                wand.storeVis(theWand, Aspect.FIRE, 25000);
+                wand.storeVis(theWand, Aspect.WATER, 25000);
+                wand.storeVis(theWand, Aspect.ORDER, 25000);
+                wand.storeVis(theWand, Aspect.ENTROPY, 25000);
                 this.items.add(theWand);
                 item.setDead();
             } else
@@ -375,24 +376,25 @@ public class TileVortex extends TileThaumcraft implements IWandable, IAspectCont
                             }
                         }
                     }
-                    final double var3 = (this.xCoord + 0.5 - eo.posX) / 15.0;
-                    final double var4 = (this.yCoord + 0.5 - eo.posY) / 15.0;
-                    final double var5 = (this.zCoord + 0.5 - eo.posZ) / 15.0;
-                    final double var6 = Math.sqrt(var3 * var3 + var4 * var4 + var5 * var5);
-                    double var7 = 1.0 - var6;
+                    final double dx = (this.xCoord + 0.5 - eo.posX) / 15.0;
+                    final double dy = (this.yCoord + 0.5 - eo.posY) / 15.0;
+                    final double dz = (this.zCoord + 0.5 - eo.posZ) / 15.0;
+                    final double dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    double var7 = 1.0 - dist;
                     final double modifier = 2.0 - this.beams / 3.0;
                     if (var7 <= 0.0) {
                         continue;
                     }
                     var7 *= var7;
-                    eo.motionX += var3 / var6 * var7 * 0.15 * modifier;
-                    eo.motionY += var4 / var6 * var7 * 0.25 * modifier;
-                    eo.motionZ += var5 / var6 * var7 * 0.15 * modifier;
+                    eo.motionX += dx / dist * var7 * 0.15 * modifier;
+                    eo.motionY += dy / dist * var7 * 0.25 * modifier;
+                    eo.motionZ += dz / dist * var7 * 0.15 * modifier;
                 }
             }
         }
         for (int i = 0; i < 3; ++i) {
-            if (!this.worldObj.isRemote && (this.beams <= 0 || this.worldObj.rand.nextInt(this.beams) == 0)) {
+            if (!this.worldObj.isRemote
+                    && (this.beams <= 0 || this.worldObj.rand.nextInt(Math.max(1, this.beams)) == 0)) {
                 int tx2 = this.xCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);
                 int ty2 = this.yCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);
                 int tz2 = this.zCoord + this.worldObj.rand.nextInt(16) - this.worldObj.rand.nextInt(16);

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -39,7 +39,7 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
     public boolean redstoned;
     public ForgeDirection dir;
     public Object theBeam;
-    public Entity[] sonicFX;
+    private Entity[] sonicFX;
 
     public TileVortexStabilizer() {
         this.xTarget = Integer.MAX_VALUE;
@@ -90,12 +90,12 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
                     // Separate if (not else if) so a new valid target is acquired in the same tick,
                     // preventing a window where beams is decremented but not yet restored.
                     final TileEntity newTE = this.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
-                    if (!this.hasTarget && newTE instanceof INode) {
+                    if (newTE instanceof INode) {
                         this.hasTarget = true;
                         this.target = newTE;
                         this.prevType = ((INode) newTE).getNodeType().ordinal();
                         this.deHungrifyTarget();
-                    } else if (!this.hasTarget && newTE instanceof TileVortex) {
+                    } else if (newTE instanceof TileVortex) {
                         this.hasTarget = true;
                         this.target = newTE;
                         this.deHungrifyTarget();

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -39,7 +39,7 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
     public boolean redstoned;
     public ForgeDirection dir;
     public Object theBeam;
-    public Entity[] sonicFX;
+    private Entity[] sonicFX;
 
     public TileVortexStabilizer() {
         this.xTarget = Integer.MAX_VALUE;
@@ -86,20 +86,19 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
                     if (this.hasTarget) {
                         this.reHungrifyTarget();
                         this.hasTarget = false;
-                    } else if (!this.hasTarget
-                            && this.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ) instanceof INode) {
-                                this.hasTarget = true;
-                                this.target = this.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
-                                this.prevType = ((INode) this.worldObj
-                                        .getTileEntity(mop.blockX, mop.blockY, mop.blockZ)).getNodeType().ordinal();
-                                this.deHungrifyTarget();
-                            } else
-                        if (!this.hasTarget && this.worldObj
-                                .getTileEntity(mop.blockX, mop.blockY, mop.blockZ) instanceof TileVortex) {
-                                    this.hasTarget = true;
-                                    this.target = this.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
-                                    this.deHungrifyTarget();
-                                }
+                    } else {
+                        final TileEntity hit = this.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
+                        if (hit instanceof INode) {
+                            this.hasTarget = true;
+                            this.target = hit;
+                            this.prevType = ((INode) hit).getNodeType().ordinal();
+                            this.deHungrifyTarget();
+                        } else if (hit instanceof TileVortex) {
+                            this.hasTarget = true;
+                            this.target = hit;
+                            this.deHungrifyTarget();
+                        }
+                    }
                     this.xTarget = mop.blockX;
                     this.yTarget = mop.blockY;
                     this.zTarget = mop.blockZ;


### PR DESCRIPTION
Remove dead MathHelper.sin assignments immediately overwritten by scale = 0.4f, inline a pointless condition = true boolean, and drop a redundant (TileVortex) cast where a pattern variable already exists. Make MAX_COUNT properly private static final, rename var3/var4/var5/var6 to dx/dy/dz/dist, fix a potential nextInt(0) crash when beams == 0, and extract repeated (ItemWandCasting) theWand.getItem() cast to a local. In TileVortexStabilizer deduplicate a triple getTileEntity call, drop tautological !hasTarget checks in else if branches, and make sonicFX private.