### PR TITLE
Fix remaining gateway portal texture bugs

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockGatewayPortal.java
@@ -232,78 +232,72 @@ public class BlockGatewayPortal extends Block {
                 }
                 case 5 -> {
                     switch (side) {
-                        case 0: {
+                        case 0 -> {
                             return this.lapiz;
                         }
-                        case 1: {
+                        case 1 -> {
                             return this.stone;
                         }
-                        case 2: {
-                            if (isXAligned) {
-                                return this.topR;
-                            }
+                        case 2 -> {
+                            if (isXAligned) return this.topR;
+                            return this.stone;
                         }
-                        case 3: {
-                            if (isXAligned) {
-                                return this.topL;
-                            }
+                        case 3 -> {
+                            if (isXAligned) return this.topL;
+                            return this.stone;
                         }
-                        case 4: {
-                            if (!isXAligned) {
-                                return this.topL;
-                            }
+                        case 4 -> {
+                            if (!isXAligned) return this.topL;
+                            return this.stone;
                         }
-                        case 5: {
-                            if (!isXAligned) {
-                                return this.topR;
-                            }
-                            break;
+                        case 5 -> {
+                            if (!isXAligned) return this.topR;
+                            return this.stone;
+                        }
+                        default -> {
+                            return this.lapiz;
                         }
                     }
-                    return this.lapiz;
                 }
                 case 6, 7, 9 -> {
                     return this.bottomSide(isXAligned, side);
                 }
                 case 8 -> {
                     switch (side) {
-                        case 0: {
+                        case 0 -> {
                             return this.lapiz;
                         }
-                        case 1: {
+                        case 1 -> {
                             return this.stone;
                         }
-                        case 2: {
-                            if (isXAligned) {
-                                return this.topL;
-                            }
+                        case 2 -> {
+                            if (isXAligned) return this.topL;
+                            return this.stone;
                         }
-                        case 3: {
-                            if (isXAligned) {
-                                return this.topR;
-                            }
+                        case 3 -> {
+                            if (isXAligned) return this.topR;
+                            return this.stone;
                         }
-                        case 4: {
-                            if (!isXAligned) {
-                                return this.topR;
-                            }
+                        case 4 -> {
+                            if (!isXAligned) return this.topR;
+                            return this.stone;
                         }
-                        case 5: {
-                            if (!isXAligned) {
-                                return this.topL;
-                            }
-                            break;
+                        case 5 -> {
+                            if (!isXAligned) return this.topL;
+                            return this.stone;
+                        }
+                        default -> {
+                            return this.lapiz;
                         }
                     }
-                    return this.lapiz;
                 }
                 case 10 -> {
                     switch (side) {
                         case 0 -> {
-                            return this.stone;
+                            return this.lapiz;
                         }
                         case 1 -> {
-                            return this.lapiz;
+                            return this.stone;
                         }
                         case 2 -> {
                             if (isXAligned) {


### PR DESCRIPTION
Cases 5 and 8 in getIcon still used colon-syntax switch after the previous fix, so fall-through caused outer faces to return wrong textures instead of stone (e.g. side 2/3 when !isXAligned fell through into side 4 returning topL). Converted both to arrow syntax so every side is handled explicitly. case 10 had case 0/1 swapped making the top face of the right upper corner block show lapiz instead of stone.

|Before|After|
|-|-|
|<img width="1416" height="825" alt="java_Cnx8RWXuEl" src="https://github.com/user-attachments/assets/5dd9c8c5-2722-4fc3-9e7b-f89f036248dd" />|<img width="2010" height="854" alt="image" src="https://github.com/user-attachments/assets/ad99cc62-add4-4ad4-bd1c-dcababd1ce16" />| 