### PR TITLE
replace magic numbers with named constants and fix exception handling

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -20,7 +20,6 @@ import net.minecraft.util.Vec3;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
 
 import thaumcraft.api.aspects.Aspect;
@@ -159,9 +158,7 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
             }
             GL11.glDisable(GL11.GL_BLEND);
             GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
-        } catch (Exception e) {
-            ThaumicHorizons.log.error("Error rendering ethereal shard", e);
-        } finally {
+        } catch (Exception ignored) {} finally {
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
+++ b/src/main/java/com/kentington/thaumichorizons/client/renderer/tile/TileEtherealShardRender.java
@@ -20,6 +20,7 @@ import net.minecraft.util.Vec3;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.tiles.TileSyntheticNode;
 
 import thaumcraft.api.aspects.Aspect;
@@ -159,7 +160,7 @@ public class TileEtherealShardRender extends TileEntitySpecialRenderer {
             GL11.glDisable(GL11.GL_BLEND);
             GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            ThaumicHorizons.log.error("Error rendering ethereal shard", e);
         } finally {
             GL11.glPopMatrix();
         }

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
@@ -45,8 +45,10 @@ public class ContainerCase extends Container {
                     new SlotLimitedByClass(ILens.class, this.input, a, 37 + a % 6 * 18, 51 + a / 6 * 18));
         }
         this.bindPlayerInventory(iinventory);
-        if (!par2World.isRemote && this.pouch != null && this.pouch.getItem() instanceof ItemLensCase) {
-            ((InventoryCase) this.input).stackList = ((ItemLensCase) this.pouch.getItem()).getInventory(this.pouch);
+        if (!par2World.isRemote && this.pouch != null
+                && this.pouch.getItem() instanceof ItemLensCase lensCase
+                && this.input instanceof InventoryCase inv) {
+            inv.stackList = lensCase.getInventory(this.pouch);
         }
         this.onCraftMatrixChanged(this.input);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
@@ -12,6 +12,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.items.lenses.ILens;
 import com.kentington.thaumichorizons.common.items.lenses.ItemLensCase;
 
@@ -48,7 +49,9 @@ public class ContainerCase extends Container {
         if (!par2World.isRemote) {
             try {
                 ((InventoryCase) this.input).stackList = ((ItemLensCase) this.pouch.getItem()).getInventory(this.pouch);
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                ThaumicHorizons.log.error("Failed to load lens case inventory", e);
+            }
         }
         this.onCraftMatrixChanged(this.input);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/container/ContainerCase.java
@@ -12,7 +12,6 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.items.lenses.ILens;
 import com.kentington.thaumichorizons.common.items.lenses.ItemLensCase;
 
@@ -46,12 +45,8 @@ public class ContainerCase extends Container {
                     new SlotLimitedByClass(ILens.class, this.input, a, 37 + a % 6 * 18, 51 + a / 6 * 18));
         }
         this.bindPlayerInventory(iinventory);
-        if (!par2World.isRemote) {
-            try {
-                ((InventoryCase) this.input).stackList = ((ItemLensCase) this.pouch.getItem()).getInventory(this.pouch);
-            } catch (Exception e) {
-                ThaumicHorizons.log.error("Failed to load lens case inventory", e);
-            }
+        if (!par2World.isRemote && this.pouch != null && this.pouch.getItem() instanceof ItemLensCase) {
+            ((InventoryCase) this.input).stackList = ((ItemLensCase) this.pouch.getItem()).getInventory(this.pouch);
         }
         this.onCraftMatrixChanged(this.input);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -31,6 +31,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import com.kentington.thaumichorizons.client.lib.GolemTHTexture;
+import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.ai.EntityAIFollowPlayer;
 import com.kentington.thaumichorizons.common.lib.networking.PacketFXBlocksplosion;
 import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
@@ -165,7 +166,9 @@ public class EntityGolemTH extends EntityGolemBase {
         int bonus = 0;
         try {
             bonus = (this.getGolemDecoration().contains("H") ? 5 : 0);
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            ThaumicHorizons.log.error("Failed to read golem decoration for health bonus", e);
+        }
         this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(this.getGolemTHType().health + bonus);
         return true;
     }
@@ -670,7 +673,9 @@ public class EntityGolemTH extends EntityGolemBase {
             int bonus = 0;
             try {
                 bonus = (this.getGolemDecoration().contains("H") ? 5 : 0);
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                ThaumicHorizons.log.error("Failed to read golem decoration for health bonus on upgrade", e);
+            }
             this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(this.type.health + bonus);
         } else if (par1 == 6) {
             this.leftArm = 5;

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -31,7 +31,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import com.kentington.thaumichorizons.client.lib.GolemTHTexture;
-import com.kentington.thaumichorizons.common.ThaumicHorizons;
 import com.kentington.thaumichorizons.common.entities.ai.EntityAIFollowPlayer;
 import com.kentington.thaumichorizons.common.lib.networking.PacketFXBlocksplosion;
 import com.kentington.thaumichorizons.common.lib.networking.PacketHandler;
@@ -163,12 +162,8 @@ public class EntityGolemTH extends EntityGolemBase {
         this.getNavigator().setAvoidsWater(
                 this.getGolemTHType() != EnumGolemTHType.ROCK && this.getGolemTHType() != EnumGolemTHType.METAL
                         && this.getGolemTHType() != EnumGolemTHType.REDSTONE);
-        int bonus = 0;
-        try {
-            bonus = (this.getGolemDecoration().contains("H") ? 5 : 0);
-        } catch (Exception e) {
-            ThaumicHorizons.log.error("Failed to read golem decoration for health bonus", e);
-        }
+        final String decor = this.getGolemDecoration();
+        final int bonus = decor == null ? 0 : (decor.contains("H") ? 5 : 0);
         this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(this.getGolemTHType().health + bonus);
         return true;
     }
@@ -670,12 +665,8 @@ public class EntityGolemTH extends EntityGolemBase {
             this.action = 6;
         } else if (par1 == 5) {
             this.healing = 5;
-            int bonus = 0;
-            try {
-                bonus = (this.getGolemDecoration().contains("H") ? 5 : 0);
-            } catch (Exception e) {
-                ThaumicHorizons.log.error("Failed to read golem decoration for health bonus on upgrade", e);
-            }
+            final String decor = this.getGolemDecoration();
+            final int bonus = decor == null ? 0 : (decor.contains("H") ? 5 : 0);
             this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(this.type.health + bonus);
         } else if (par1 == 6) {
             this.leftArm = 5;

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
@@ -84,15 +84,7 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                     if (stack.getItem() != null) {
                         try {
                             text = stack.getDisplayName();
-                        } catch (Exception e) {
-                            ThaumicHorizons.log.warn("Failed to get display name for scan target", e);
-                        }
-                    } else if (stack.getItem() != null) {
-                        try {
-                            text = stack.getItem().getItemStackDisplayName(stack);
-                        } catch (Exception e) {
-                            ThaumicHorizons.log.warn("Failed to get item stack display name for scan target", e);
-                        }
+                        } catch (Exception ignored) {}
                     }
                 }
                 if (scan.type == 2) {

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
@@ -237,9 +237,7 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                             if (is == null) {
                                 is = BlockUtils.createStackedBlock(bi, md);
                             }
-                        } catch (Exception e) {
-                            ThaumicHorizons.log.warn("Failed to create stacked block for scan", e);
-                        }
+                        } catch (Exception ignored) {}
                         try {
                             if (is == null) {
                                 sr2 = new ScanResult((byte) 1, Block.getIdFromBlock(bi), md, null, "");
@@ -251,9 +249,7 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                                         null,
                                         "");
                             }
-                        } catch (Exception e) {
-                            ThaumicHorizons.log.warn("Failed to create scan result for block", e);
-                        }
+                        } catch (Exception ignored) {}
                         if (ScanManager.isValidScanTarget(p, sr2, "@")) {
                             Thaumcraft.proxy.blockRunes(
                                     world,

--- a/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/lenses/ItemLensOrderEntropy.java
@@ -84,11 +84,15 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                     if (stack.getItem() != null) {
                         try {
                             text = stack.getDisplayName();
-                        } catch (Exception ignored) {}
+                        } catch (Exception e) {
+                            ThaumicHorizons.log.warn("Failed to get display name for scan target", e);
+                        }
                     } else if (stack.getItem() != null) {
                         try {
                             text = stack.getItem().getItemStackDisplayName(stack);
-                        } catch (Exception ignored) {}
+                        } catch (Exception e) {
+                            ThaumicHorizons.log.warn("Failed to get item stack display name for scan target", e);
+                        }
                     }
                 }
                 if (scan.type == 2) {
@@ -233,7 +237,9 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                             if (is == null) {
                                 is = BlockUtils.createStackedBlock(bi, md);
                             }
-                        } catch (Exception ignored) {}
+                        } catch (Exception e) {
+                            ThaumicHorizons.log.warn("Failed to create stacked block for scan", e);
+                        }
                         try {
                             if (is == null) {
                                 sr2 = new ScanResult((byte) 1, Block.getIdFromBlock(bi), md, null, "");
@@ -245,7 +251,9 @@ public class ItemLensOrderEntropy extends Item implements ILens {
                                         null,
                                         "");
                             }
-                        } catch (Exception ignored) {}
+                        } catch (Exception e) {
+                            ThaumicHorizons.log.warn("Failed to create scan result for block", e);
+                        }
                         if (ScanManager.isValidScanTarget(p, sr2, "@")) {
                             Thaumcraft.proxy.blockRunes(
                                     world,

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
@@ -30,8 +30,14 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
     int progress;
     static final int PROGRESS_MAX = 9600;
     public int souls;
+    static final int MAX_SOULS = 16;
     int essentia;
     static final int ESSENTIA_MAX = 4000;
+    // Threshold for drawing more essentia (3 MIND aspects * 1000 each)
+    static final int ESSENTIA_DRAW_THRESHOLD = 3000;
+    static final int ESSENTIA_PER_ASPECT = 1000;
+    static final int SUCTION_PRESSURE = 128;
+    static final double PLAYER_REACH_SQ = 64.0;
     public float rota;
     public int forging;
 
@@ -83,8 +89,8 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
     public void addSoulBits(final int bits) {
         this.progress += bits;
         this.essentia -= bits;
-        if (this.progress >= 9600) {
-            this.progress -= 9600;
+        if (this.progress >= PROGRESS_MAX) {
+            this.progress -= PROGRESS_MAX;
             ++this.souls;
         }
         this.forging = 3;
@@ -94,12 +100,12 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     @Override
     public boolean canAcceptSouls() {
-        return this.essentia > 0 && this.souls < 16;
+        return this.essentia > 0 && this.souls < MAX_SOULS;
     }
 
     public void updateEntity() {
         super.updateEntity();
-        if (this.essentia < 3000) {
+        if (this.essentia < ESSENTIA_DRAW_THRESHOLD) {
             this.drawEssentia();
         }
         if (this.forging > 0) {
@@ -113,7 +119,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     public boolean isUseableByPlayer(final EntityPlayer p_70300_1_) {
         return this.worldObj.getTileEntity(this.xCoord, this.yCoord, this.zCoord) == this
-                && p_70300_1_.getDistanceSq(this.xCoord + 0.5, this.yCoord + 0.5, this.zCoord + 0.5) <= 64.0;
+                && p_70300_1_.getDistanceSq(this.xCoord + 0.5, this.yCoord + 0.5, this.zCoord + 0.5) <= PLAYER_REACH_SQ;
     }
 
     void drawEssentia() {
@@ -158,12 +164,12 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
         if (this.essentia <= 0) {
             return null;
         }
-        return new AspectList().add(Aspect.MIND, (int) Math.ceil(this.essentia / 1000.0f));
+        return new AspectList().add(Aspect.MIND, (int) Math.ceil(this.essentia / (float) ESSENTIA_PER_ASPECT));
     }
 
     @Override
     public void setAspects(final AspectList aspects) {
-        this.essentia = aspects.getAmount(Aspect.MIND) * 1000;
+        this.essentia = aspects.getAmount(Aspect.MIND) * ESSENTIA_PER_ASPECT;
     }
 
     @Override
@@ -188,7 +194,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     @Override
     public boolean doesContainerContainAmount(final Aspect tag, final int amount) {
-        return tag.getTag().equals(Aspect.MIND.getTag()) && this.essentia / 1000 >= amount;
+        return tag.getTag().equals(Aspect.MIND.getTag()) && this.essentia / ESSENTIA_PER_ASPECT >= amount;
     }
 
     @Override
@@ -199,7 +205,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
     @Override
     public int containerContains(final Aspect tag) {
         if (tag.getTag().equals(Aspect.MIND.getTag())) {
-            return this.essentia / 1000;
+            return this.essentia / ESSENTIA_PER_ASPECT;
         }
         return 0;
     }
@@ -229,7 +235,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     @Override
     public int getSuctionAmount(final ForgeDirection face) {
-        return (this.essentia < 3000) ? 128 : 0;
+        return (this.essentia < ESSENTIA_DRAW_THRESHOLD) ? SUCTION_PRESSURE : 0;
     }
 
     @Override
@@ -239,8 +245,8 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     @Override
     public int addEssentia(final Aspect aspect, final int amount, final ForgeDirection face) {
-        if (this.essentia < 3000) {
-            this.essentia += 1000;
+        if (this.essentia < ESSENTIA_DRAW_THRESHOLD) {
+            this.essentia += ESSENTIA_PER_ASPECT;
             this.markDirty();
             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
             return 1;
@@ -255,7 +261,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
 
     @Override
     public int getEssentiaAmount(final ForgeDirection face) {
-        return this.essentia / 1000;
+        return this.essentia / ESSENTIA_PER_ASPECT;
     }
 
     @Override

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileSoulforge.java
@@ -89,7 +89,7 @@ public class TileSoulforge extends TileThaumcraft implements ISoulReceiver, IEss
     public void addSoulBits(final int bits) {
         this.progress += bits;
         this.essentia -= bits;
-        if (this.progress >= PROGRESS_MAX) {
+        while (this.progress >= PROGRESS_MAX) {
             this.progress -= PROGRESS_MAX;
             ++this.souls;
         }

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
@@ -710,80 +710,75 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
     private void getSurroundings() {
         final ArrayList<ChunkCoordinates> stuff = new ArrayList<>();
         this.pedestals.clear();
-        try {
-            for (int xx = -PEDESTAL_SEARCH_HORIZONTAL; xx <= PEDESTAL_SEARCH_HORIZONTAL; ++xx) {
-                for (int zz = -PEDESTAL_SEARCH_HORIZONTAL; zz <= PEDESTAL_SEARCH_HORIZONTAL; ++zz) {
-                    boolean skip = false;
-                    for (int yy = -PEDESTAL_SEARCH_Y_DOWN; yy <= PEDESTAL_SEARCH_Y_UP; ++yy) {
-                        if (xx != 0 || zz != 0) {
-                            final int x = this.xCoord + xx;
-                            final int y = this.yCoord - yy;
-                            final int z = this.zCoord + zz;
-                            final TileEntity te = this.worldObj.getTileEntity(x, y, z);
-                            if (!skip && yy > 0
-                                    && Math.abs(xx) <= PEDESTAL_SYMMETRY_RANGE
-                                    && Math.abs(zz) <= PEDESTAL_SYMMETRY_RANGE
-                                    && te instanceof TilePedestal) {
-                                this.pedestals.add(new ChunkCoordinates(x, y, z));
-                                skip = true;
-                            } else {
-                                final Block bi = this.worldObj.getBlock(x, y, z);
-                                if (bi == Blocks.skull
-                                        || (bi instanceof IInfusionStabiliser && ((IInfusionStabiliser) bi)
-                                                .canStabaliseInfusion(this.getWorldObj(), x, y, z))) {
-                                    stuff.add(new ChunkCoordinates(x, y, z));
-                                }
+        for (int xx = -PEDESTAL_SEARCH_HORIZONTAL; xx <= PEDESTAL_SEARCH_HORIZONTAL; ++xx) {
+            for (int zz = -PEDESTAL_SEARCH_HORIZONTAL; zz <= PEDESTAL_SEARCH_HORIZONTAL; ++zz) {
+                boolean skip = false;
+                for (int yy = -PEDESTAL_SEARCH_Y_DOWN; yy <= PEDESTAL_SEARCH_Y_UP; ++yy) {
+                    if (xx != 0 || zz != 0) {
+                        final int x = this.xCoord + xx;
+                        final int y = this.yCoord - yy;
+                        final int z = this.zCoord + zz;
+                        final TileEntity te = this.worldObj.getTileEntity(x, y, z);
+                        if (!skip && yy > 0
+                                && Math.abs(xx) <= PEDESTAL_SYMMETRY_RANGE
+                                && Math.abs(zz) <= PEDESTAL_SYMMETRY_RANGE
+                                && te instanceof TilePedestal) {
+                            this.pedestals.add(new ChunkCoordinates(x, y, z));
+                            skip = true;
+                        } else {
+                            final Block bi = this.worldObj.getBlock(x, y, z);
+                            if (bi == Blocks.skull || (bi instanceof IInfusionStabiliser
+                                    && ((IInfusionStabiliser) bi).canStabaliseInfusion(this.getWorldObj(), x, y, z))) {
+                                stuff.add(new ChunkCoordinates(x, y, z));
                             }
                         }
                     }
                 }
             }
-            this.symmetry = 0;
-            for (final ChunkCoordinates cc : this.pedestals) {
-                boolean items = false;
-                final int x2 = this.xCoord - cc.posX;
-                final int z2 = this.zCoord - cc.posZ;
-                TileEntity te2 = this.worldObj.getTileEntity(cc.posX, cc.posY, cc.posZ);
-                if (te2 instanceof TilePedestal) {
-                    this.symmetry += 2;
-                    if (((TilePedestal) te2).getStackInSlot(0) != null) {
-                        ++this.symmetry;
-                        items = true;
-                    }
-                }
-                final int xx2 = this.xCoord + x2;
-                final int zz2 = this.zCoord + z2;
-                te2 = this.worldObj.getTileEntity(xx2, cc.posY, zz2);
-                if (te2 instanceof TilePedestal) {
-                    this.symmetry -= 2;
-                    if (((TilePedestal) te2).getStackInSlot(0) == null || !items) {
-                        continue;
-                    }
-                    --this.symmetry;
-                }
-            }
-            float sym = 0.0f;
-            for (final ChunkCoordinates cc2 : stuff) {
-                final boolean items2 = false;
-                final int x = this.xCoord - cc2.posX;
-                final int z3 = this.zCoord - cc2.posZ;
-                Block bi2 = this.worldObj.getBlock(cc2.posX, cc2.posY, cc2.posZ);
-                if (bi2 == Blocks.skull || (bi2 instanceof IInfusionStabiliser && ((IInfusionStabiliser) bi2)
-                        .canStabaliseInfusion(this.getWorldObj(), cc2.posX, cc2.posY, cc2.posZ))) {
-                    sym += 0.1f;
-                }
-                final int xx3 = this.xCoord + x;
-                final int zz3 = this.zCoord + z3;
-                bi2 = this.worldObj.getBlock(xx3, cc2.posY, zz3);
-                if (bi2 == Blocks.skull || (bi2 instanceof IInfusionStabiliser && ((IInfusionStabiliser) bi2)
-                        .canStabaliseInfusion(this.getWorldObj(), cc2.posX, cc2.posY, cc2.posZ))) {
-                    sym -= 0.2f;
-                }
-            }
-            this.symmetry += (int) sym;
-        } catch (Exception e) {
-            ThaumicHorizons.log.error("Error calculating vat symmetry", e);
         }
+        this.symmetry = 0;
+        for (final ChunkCoordinates cc : this.pedestals) {
+            boolean items = false;
+            final int x2 = this.xCoord - cc.posX;
+            final int z2 = this.zCoord - cc.posZ;
+            TileEntity te2 = this.worldObj.getTileEntity(cc.posX, cc.posY, cc.posZ);
+            if (te2 instanceof TilePedestal) {
+                this.symmetry += 2;
+                if (((TilePedestal) te2).getStackInSlot(0) != null) {
+                    ++this.symmetry;
+                    items = true;
+                }
+            }
+            final int xx2 = this.xCoord + x2;
+            final int zz2 = this.zCoord + z2;
+            te2 = this.worldObj.getTileEntity(xx2, cc.posY, zz2);
+            if (te2 instanceof TilePedestal) {
+                this.symmetry -= 2;
+                if (((TilePedestal) te2).getStackInSlot(0) == null || !items) {
+                    continue;
+                }
+                --this.symmetry;
+            }
+        }
+        float sym = 0.0f;
+        for (final ChunkCoordinates cc2 : stuff) {
+            final boolean items2 = false;
+            final int x = this.xCoord - cc2.posX;
+            final int z3 = this.zCoord - cc2.posZ;
+            Block bi2 = this.worldObj.getBlock(cc2.posX, cc2.posY, cc2.posZ);
+            if (bi2 == Blocks.skull || (bi2 instanceof IInfusionStabiliser && ((IInfusionStabiliser) bi2)
+                    .canStabaliseInfusion(this.getWorldObj(), cc2.posX, cc2.posY, cc2.posZ))) {
+                sym += 0.1f;
+            }
+            final int xx3 = this.xCoord + x;
+            final int zz3 = this.zCoord + z3;
+            bi2 = this.worldObj.getBlock(xx3, cc2.posY, zz3);
+            if (bi2 == Blocks.skull || (bi2 instanceof IInfusionStabiliser && ((IInfusionStabiliser) bi2)
+                    .canStabaliseInfusion(this.getWorldObj(), cc2.posX, cc2.posY, cc2.posZ))) {
+                sym -= 0.2f;
+            }
+        }
+        this.symmetry += (int) sym;
     }
 
     private void doEffects() {

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVat.java
@@ -78,6 +78,45 @@ import thaumcraft.common.tiles.TilePedestal;
 
 public class TileVat extends TileThaumcraft implements IAspectContainer, IEssentiaTransport, ISidedInventory {
 
+    // Timers and progress values (in ticks)
+    private static final int CLONE_PROGRESS = 800;
+    private static final int COUNT_DELAY = 10;
+    private static final int HEAL_ASPECT_COOLDOWN = 40;
+    private static final int LIFE_ASPECT_COOLDOWN = 50;
+    private static final int EFFIGY_PROGRESS = 80;
+    private static final int BLOOD_SAMPLE_INITIAL_PROGRESS = 40;
+    private static final int INFUSER_SOUND_INTERVAL = 65;
+    private static final int CRAFTCOUNT_WIND_DOWN_MAX = 50;
+    private static final int INSTABILITY_EFFECT_CHANCE = 200;
+    private static final int INSTABILITY_CRAFT_CHANCE = 500;
+    private static final int INSTABILITY_INCREASE_CHANCE_BASE = 100;
+    private static final int MAX_INSTABILITY = 25;
+
+    // Healing amounts
+    private static final float STRONG_HEAL_AMOUNT = 8.0f;
+    private static final float WEAK_HEAL_AMOUNT = 4.0f;
+
+    // Essentia costs
+    private static final int EFFIGY_ESSENTIA_AMOUNT = 8;
+    private static final int BLOOD_SAMPLE_LIFE_COST = 4;
+    private static final int VIS_DRAIN_AMOUNT = 100;
+
+    // Instability damage divisor
+    private static final float INSTABILITY_DAMAGE_DIVISOR = 10.0f;
+
+    // Pedestal search radius
+    private static final int PEDESTAL_SEARCH_HORIZONTAL = 12;
+    private static final int PEDESTAL_SEARCH_Y_DOWN = 5;
+    private static final int PEDESTAL_SEARCH_Y_UP = 10;
+    private static final int PEDESTAL_SYMMETRY_RANGE = 8;
+
+    // Self-infusion slots
+    private static final int SELF_INFUSION_SLOTS = 12;
+    private static final float SELF_INFUSION_INITIAL_HEALTH = 20.0f;
+
+    // Particle count for infuser effects
+    private static final int INFUSER_PARTICLE_COUNT = 25;
+
     public int mode;
     AspectList myEssentia;
     AspectList essentiaDemanded;
@@ -86,7 +125,6 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
     public ItemStack nutrients;
     public int progress;
     private EntityLivingBase entityContained;
-    public final int CLONE_TIME = 800;
     public int[] selfInfusions;
     public float selfInfusionHealth;
     private final ArrayList<ChunkCoordinates> pedestals;
@@ -105,7 +143,6 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
     public int count;
     public int craftCount;
     public float startUp;
-    private final int countDelay;
     ArrayList<ItemStack> ingredients;
     public HashMap<String, SourceFX> sourceFX;
     private NBTTagCompound entityNBTObj = null;
@@ -119,8 +156,8 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         this.sample = null;
         this.nutrients = null;
         this.entityContained = null;
-        this.selfInfusions = new int[12];
-        this.selfInfusionHealth = 20.0f;
+        this.selfInfusions = new int[SELF_INFUSION_SLOTS];
+        this.selfInfusionHealth = SELF_INFUSION_INITIAL_HEALTH;
         this.pedestals = new ArrayList<>();
         this.dangerCount = 0;
         this.checkSurroundings = true;
@@ -136,7 +173,6 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         this.itemCount = 0;
         this.count = 0;
         this.craftCount = 0;
-        this.countDelay = 10;
         this.ingredients = new ArrayList<>();
         this.sourceFX = new HashMap<>();
     }
@@ -196,7 +232,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                             this.mode = 0;
                             this.markDirty();
                             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-                            this.selfInfusions = new int[12];
+                            this.selfInfusions = new int[SELF_INFUSION_SLOTS];
                             --possibleJar.stackSize;
                         }
                     } else {
@@ -273,22 +309,22 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 if (this.getEntityContained().getHealth() < this.getEntityContained().getMaxHealth()) {
                     if (this.getEntityContained().getCreatureAttribute() != EnumCreatureAttribute.UNDEAD) {
                         if (this.myEssentia.getAmount(Aspect.HEAL) > 0 && this.progress <= 0) {
-                            this.getEntityContained().heal(8.0f);
+                            this.getEntityContained().heal(STRONG_HEAL_AMOUNT);
                             this.myEssentia.remove(Aspect.HEAL, 1);
                             this.markDirty();
                             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-                            this.progress += 40;
+                            this.progress += HEAL_ASPECT_COOLDOWN;
                         }
                         if (this.getEntityContained().getHealth() < this.getEntityContained().getMaxHealth()
                                 && this.essentiaDemanded.getAmount(Aspect.HEAL) < 1) {
                             this.essentiaDemanded.add(Aspect.HEAL, 1);
                         }
                         if (this.myEssentia.getAmount(Aspect.LIFE) > 0 && this.progress <= 0) {
-                            this.getEntityContained().heal(4.0f);
+                            this.getEntityContained().heal(WEAK_HEAL_AMOUNT);
                             this.myEssentia.remove(Aspect.LIFE, 1);
                             this.markDirty();
                             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-                            this.progress += 50;
+                            this.progress += LIFE_ASPECT_COOLDOWN;
                         }
                         if (this.getEntityContained().getHealth() < this.getEntityContained().getMaxHealth()
                                 && this.essentiaDemanded.getAmount(Aspect.LIFE) < 1) {
@@ -296,22 +332,22 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                         }
                     } else {
                         if (this.myEssentia.getAmount(Aspect.UNDEAD) > 0 && this.progress <= 0) {
-                            this.getEntityContained().heal(8.0f);
+                            this.getEntityContained().heal(STRONG_HEAL_AMOUNT);
                             this.myEssentia.remove(Aspect.UNDEAD, 1);
                             this.markDirty();
                             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-                            this.progress += 40;
+                            this.progress += HEAL_ASPECT_COOLDOWN;
                         }
                         if (this.getEntityContained().getHealth() < this.getEntityContained().getMaxHealth()
                                 && this.essentiaDemanded.getAmount(Aspect.UNDEAD) < 1) {
                             this.essentiaDemanded.add(Aspect.UNDEAD, 1);
                         }
                         if (this.myEssentia.getAmount(Aspect.DEATH) > 0 && this.progress <= 0) {
-                            this.getEntityContained().heal(4.0f);
+                            this.getEntityContained().heal(WEAK_HEAL_AMOUNT);
                             this.myEssentia.remove(Aspect.DEATH, 1);
                             this.markDirty();
                             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
-                            this.progress += 50;
+                            this.progress += LIFE_ASPECT_COOLDOWN;
                         }
                         if (this.getEntityContained().getHealth() < this.getEntityContained().getMaxHealth()
                                 && this.essentiaDemanded.getAmount(Aspect.DEATH) < 1) {
@@ -355,13 +391,14 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 }
             } else if (this.sample != null && this.sample.getItem() == ThaumicHorizons.itemCorpseEffigy) {
                 this.mode = 3;
-                this.essentiaDemanded = new AspectList().add(Aspect.LIFE, 8).add(Aspect.HEAL, 8);
-                this.progress = 80;
+                this.essentiaDemanded = new AspectList().add(Aspect.LIFE, EFFIGY_ESSENTIA_AMOUNT)
+                        .add(Aspect.HEAL, EFFIGY_ESSENTIA_AMOUNT);
+                this.progress = EFFIGY_PROGRESS;
                 this.markDirty();
                 this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
             } else if (this.sample != null && this.nutrients != null) {
                 this.mode = 1;
-                this.essentiaDemanded = new AspectList().add(Aspect.LIFE, 4);
+                this.essentiaDemanded = new AspectList().add(Aspect.LIFE, BLOOD_SAMPLE_LIFE_COST);
                 if (this.sample.getItem() == ThaumicHorizons.itemSyringeBloodSample && this.sample.hasTagCompound()
                         && this.sample.stackTagCompound.getCompoundTag("critter") != null
                         && this.sample.stackTagCompound.getCompoundTag("critter").getCompoundTag("ForgeData") != null) {
@@ -378,7 +415,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                         }
                     }
                 }
-                this.progress = 40;
+                this.progress = BLOOD_SAMPLE_INITIAL_PROGRESS;
                 this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
                 this.markDirty();
             }
@@ -415,7 +452,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 if (this.nutrients.stackSize <= 0) {
                     this.nutrients = null;
                 }
-                this.progress = 800;
+                this.progress = CLONE_PROGRESS;
                 this.essentiaDemanded = new AspectList();
                 this.myEssentia = new AspectList();
                 if (this.getEntityContained() == null) {
@@ -437,7 +474,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
             if (this.checkSurroundings) {
                 this.checkSurroundings = false;
                 this.getSurroundings();
-            } else if (this.count % this.countDelay == 0) {
+            } else if (this.count % COUNT_DELAY == 0) {
                 this.craftCycle();
                 this.markDirty();
             }
@@ -463,7 +500,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 Thaumcraft.proxy.blockSparkle(this.worldObj, this.xCoord, this.yCoord - 2, this.zCoord, 16720418, 20);
                 Thaumcraft.proxy.blockSparkle(this.worldObj, this.xCoord, this.yCoord - 1, this.zCoord, 16720418, 20);
                 this.mode = 4;
-                this.selfInfusionHealth = 20.0f;
+                this.selfInfusionHealth = SELF_INFUSION_INITIAL_HEALTH;
                 this.sample = null;
                 this.essentiaDemanded = new AspectList();
                 this.myEssentia = new AspectList();
@@ -674,18 +711,18 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         final ArrayList<ChunkCoordinates> stuff = new ArrayList<>();
         this.pedestals.clear();
         try {
-            for (int xx = -12; xx <= 12; ++xx) {
-                for (int zz = -12; zz <= 12; ++zz) {
+            for (int xx = -PEDESTAL_SEARCH_HORIZONTAL; xx <= PEDESTAL_SEARCH_HORIZONTAL; ++xx) {
+                for (int zz = -PEDESTAL_SEARCH_HORIZONTAL; zz <= PEDESTAL_SEARCH_HORIZONTAL; ++zz) {
                     boolean skip = false;
-                    for (int yy = -5; yy <= 10; ++yy) {
+                    for (int yy = -PEDESTAL_SEARCH_Y_DOWN; yy <= PEDESTAL_SEARCH_Y_UP; ++yy) {
                         if (xx != 0 || zz != 0) {
                             final int x = this.xCoord + xx;
                             final int y = this.yCoord - yy;
                             final int z = this.zCoord + zz;
                             final TileEntity te = this.worldObj.getTileEntity(x, y, z);
                             if (!skip && yy > 0
-                                    && Math.abs(xx) <= 8
-                                    && Math.abs(zz) <= 8
+                                    && Math.abs(xx) <= PEDESTAL_SYMMETRY_RANGE
+                                    && Math.abs(zz) <= PEDESTAL_SYMMETRY_RANGE
                                     && te instanceof TilePedestal) {
                                 this.pedestals.add(new ChunkCoordinates(x, y, z));
                                 skip = true;
@@ -744,7 +781,9 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 }
             }
             this.symmetry += (int) sym;
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            ThaumicHorizons.log.error("Error calculating vat symmetry", e);
+        }
     }
 
     private void doEffects() {
@@ -752,7 +791,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
             if (this.craftCount == 0) {
                 this.worldObj
                         .playSound(this.xCoord, this.yCoord, this.zCoord, "thaumcraft:infuserstart", 0.5f, 1.0f, false);
-            } else if (this.craftCount % 65 == 0) {
+            } else if (this.craftCount % INFUSER_SOUND_INTERVAL == 0) {
                 this.worldObj.playSound(this.xCoord, this.yCoord, this.zCoord, "thaumcraft:infuser", 0.5f, 1.0f, false);
             }
             ++this.craftCount;
@@ -764,15 +803,15 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                     0.5f + this.worldObj.rand.nextFloat() * 0.2f,
                     0.1f,
                     0.7f + this.worldObj.rand.nextFloat() * 0.3f,
-                    25,
+                    INFUSER_PARTICLE_COUNT,
                     -0.03f);
         } else if (this.craftCount > 0) {
             this.craftCount -= 2;
             if (this.craftCount < 0) {
                 this.craftCount = 0;
             }
-            if (this.craftCount > 50) {
-                this.craftCount = 50;
+            if (this.craftCount > CRAFTCOUNT_WIND_DOWN_MAX) {
+                this.craftCount = CRAFTCOUNT_WIND_DOWN_MAX;
             }
         }
         if (this.mode == 2 && this.startUp != 1.0f) {
@@ -858,7 +897,8 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 this.sourceFX.put(fxk, fx);
             }
         }
-        if (this.mode == 2 && this.instability > 0 && this.worldObj.rand.nextInt(200) <= this.instability) {
+        if (this.mode == 2 && this.instability > 0
+                && this.worldObj.rand.nextInt(INSTABILITY_EFFECT_CHANCE) <= this.instability) {
             Thaumcraft.proxy.nodeBolt(
                     this.worldObj,
                     this.xCoord + 0.5f,
@@ -871,7 +911,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
     }
 
     public void craftCycle() {
-        if (this.instability > 0 && this.worldObj.rand.nextInt(500) <= this.instability) {
+        if (this.instability > 0 && this.worldObj.rand.nextInt(INSTABILITY_CRAFT_CHANCE) <= this.instability) {
             switch (this.worldObj.rand.nextInt(21)) {
                 case 0, 2, 10, 13 -> {
                     this.inEvEjectItem(0);
@@ -920,24 +960,40 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         if (this.instability > 0 && this.entityContained != null) {
             float visDrawn = 999.0f;
             if (!this.worldObj.isRemote) {
-                float temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.EARTH, 100);
+                float temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.EARTH,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
-                temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.WATER, 100);
+                temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.WATER,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
-                temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.ORDER, 100);
+                temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.ORDER,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
             }
-            this.getEntityContained()
-                    .setHealth(this.getEntityContained().getHealth() - this.instability / 10.0f / (5.0f + visDrawn));
+            this.getEntityContained().setHealth(
+                    this.getEntityContained().getHealth()
+                            - this.instability / INSTABILITY_DAMAGE_DIVISOR / (5.0f + visDrawn));
             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
             if (this.getEntityContained().getHealth() <= 0.0f) {
                 this.killSubject();
@@ -946,23 +1002,38 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         } else if (this.instability > 0) {
             float visDrawn = 999.0f;
             if (!this.worldObj.isRemote) {
-                float temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.EARTH, 100);
+                float temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.EARTH,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
-                temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.WATER, 100);
+                temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.WATER,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
-                temp = VisNetHandler
-                        .drainVis(this.worldObj, this.xCoord, this.yCoord + 1, this.zCoord, Aspect.ORDER, 100);
+                temp = VisNetHandler.drainVis(
+                        this.worldObj,
+                        this.xCoord,
+                        this.yCoord + 1,
+                        this.zCoord,
+                        Aspect.ORDER,
+                        VIS_DRAIN_AMOUNT);
                 if (temp < visDrawn) {
                     visDrawn = temp;
                 }
             }
-            this.selfInfusionHealth -= this.instability / 10.0f / (5.0f + visDrawn);
+            this.selfInfusionHealth -= this.instability / INSTABILITY_DAMAGE_DIVISOR / (5.0f + visDrawn);
             this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
             if (this.selfInfusionHealth <= 0.0f) {
                 this.killSubject();
@@ -982,11 +1053,12 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                         this.markDirty();
                         return;
                     }
-                    if (this.worldObj.rand.nextInt(100 - this.recipeInstability * 3) == 0) {
+                    if (this.worldObj.rand.nextInt(INSTABILITY_INCREASE_CHANCE_BASE - this.recipeInstability * 3)
+                            == 0) {
                         ++this.instability;
                     }
-                    if (this.instability > 25) {
-                        this.instability = 25;
+                    if (this.instability > MAX_INSTABILITY) {
+                        this.instability = MAX_INSTABILITY;
                     }
                     this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
                     this.markDirty();
@@ -1354,7 +1426,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
         this.nutrients = ItemStack.loadItemStackFromNBT(nbttagcompound.getCompoundTag("nutrients"));
         this.selfInfusions = nbttagcompound.getIntArray("selfInfusions");
         if (this.selfInfusions.length == 0) {
-            this.selfInfusions = new int[12];
+            this.selfInfusions = new int[SELF_INFUSION_SLOTS];
         }
         this.selfInfusionHealth = nbttagcompound.getFloat("selfInfusionHealth");
     }
@@ -1515,7 +1587,7 @@ public class TileVat extends TileThaumcraft implements IAspectContainer, IEssent
                 }
             }
         }
-        this.selfInfusions = new int[12];
+        this.selfInfusions = new int[SELF_INFUSION_SLOTS];
         this.setEntityContained(null);
         this.mode = 0;
         this.currentlySucking = null;


### PR DESCRIPTION
Extracted ~30 magic numbers in TileVat and TileSoulforge into static final constants (timers, heal amounts, essentia thresholds, search radii, etc).

For exception handling: replaced catch blocks with explicit checks where the failure condition is knowable (golem decoration null check, ContainerCase instanceof check), removed unnecessary try/catch where exceptions shouldn't occur (TileVat symmetry calculation), and kept silent catch only where Thaumcraft itself ignores the same exceptions (ScanResult StackOverflow, render errors).

Also fixed a redundant else-if branch in ItemLensOrderEntropy and a soul bit overflow bug in TileSoulforge.