### PR TITLE
Fix stabilizer restoring hungry node type when second stabilizer is still active

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -166,13 +166,27 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
 
     public void reHungrifyTarget() {
         if (this.target instanceof INode) {
-            ((INode) this.target).setNodeType(NodeType.values()[this.prevType]);
+            if (!isNodeTargetedByOtherStabilizer()) {
+                ((INode) this.target).setNodeType(NodeType.values()[this.prevType]);
+            }
         } else if (this.target instanceof TileVortex) {
             --((TileVortex) this.target).beams;
         }
         if (this.target != null) {
             this.target.markDirty();
         }
+    }
+
+    private boolean isNodeTargetedByOtherStabilizer() {
+        for (Object obj : this.worldObj.loadedTileEntityList) {
+            if (obj instanceof TileVortexStabilizer && obj != this) {
+                TileVortexStabilizer other = (TileVortexStabilizer) obj;
+                if (other.hasTarget && other.target == this.target) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     void deHungrifyTarget() {

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -185,10 +185,8 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
         int tz = this.target.zCoord;
         for (ForgeDirection d : ForgeDirection.VALID_DIRECTIONS) {
             for (int dist = 1; dist <= 10; dist++) {
-                TileEntity te = this.worldObj.getTileEntity(
-                        tx - d.offsetX * dist,
-                        ty - d.offsetY * dist,
-                        tz - d.offsetZ * dist);
+                TileEntity te = this.worldObj
+                        .getTileEntity(tx - d.offsetX * dist, ty - d.offsetY * dist, tz - d.offsetZ * dist);
                 if (te instanceof TileVortexStabilizer && te != this) {
                     TileVortexStabilizer other = (TileVortexStabilizer) te;
                     if (other.hasTarget && other.target == this.target) {

--- a/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/tiles/TileVortexStabilizer.java
@@ -178,11 +178,22 @@ public class TileVortexStabilizer extends TileThaumcraft implements IWandable {
     }
 
     private boolean isNodeTargetedByOtherStabilizer() {
-        for (Object obj : this.worldObj.loadedTileEntityList) {
-            if (obj instanceof TileVortexStabilizer && obj != this) {
-                TileVortexStabilizer other = (TileVortexStabilizer) obj;
-                if (other.hasTarget && other.target == this.target) {
-                    return true;
+        // A stabilizer can only reach a node from up to 10 blocks away in one of 6 directions,
+        // so check those 60 positions instead of scanning all loaded tile entities.
+        int tx = this.target.xCoord;
+        int ty = this.target.yCoord;
+        int tz = this.target.zCoord;
+        for (ForgeDirection d : ForgeDirection.VALID_DIRECTIONS) {
+            for (int dist = 1; dist <= 10; dist++) {
+                TileEntity te = this.worldObj.getTileEntity(
+                        tx - d.offsetX * dist,
+                        ty - d.offsetY * dist,
+                        tz - d.offsetZ * dist);
+                if (te instanceof TileVortexStabilizer && te != this) {
+                    TileVortexStabilizer other = (TileVortexStabilizer) te;
+                    if (other.hasTarget && other.target == this.target) {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Stabilizer would restore a node's hungry type on deactivation even if another stabilizer was still targeting the same node, because setNodeType was called unconditionally. Fixed by checking loadedTileEntityList for other active stabilizers before restoring the type. Vortexes were unaffected as they already use a beams counter.