### PR TITLE
Implement Chat Components for Entity Names (+ cleanups)

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityEndersteed.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityEndersteed.java
@@ -8,6 +8,8 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.passive.EntityHorse;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
@@ -26,10 +28,11 @@ public class EntityEndersteed extends EntityHorse {
         this.initialized = false;
     }
 
+    @Override
     public void readEntityFromNBT(final NBTTagCompound p_70037_1_) {
         super.readEntityFromNBT(p_70037_1_);
         if (!(this.initialized = p_70037_1_.getBoolean("initialized"))) {
-            final Multimap map = HashMultimap.create();
+            final Multimap<String, AttributeModifier> map = HashMultimap.create();
             map.put("generic.movementSpeed", new AttributeModifier("generic.movementSpeed", 0.1, 1));
             map.put("horse.jumpStrength", new AttributeModifier("horse.jumpStrength", 0.25, 1));
             map.put("generic.maxHealth", new AttributeModifier("generic.maxHealth", 4.0, 1));
@@ -38,11 +41,13 @@ public class EntityEndersteed extends EntityHorse {
         }
     }
 
+    @Override
     public void writeEntityToNBT(final NBTTagCompound p_70014_1_) {
         super.writeEntityToNBT(p_70014_1_);
         p_70014_1_.setBoolean("initialized", this.initialized);
     }
 
+    @Override
     public void setJumpPower(final int p_110206_1_) {
         final double blocks = p_110206_1_ / 7.0;
         this.teleportTo(
@@ -51,11 +56,21 @@ public class EntityEndersteed extends EntityHorse {
                 this.posZ + blocks * Math.cos(Math.toRadians(this.rotationYaw)));
     }
 
+    @Override
     public String getCommandSenderName() {
         if (this.hasCustomNameTag()) {
             return this.getCustomNameTag();
         }
         return StatCollector.translateToLocal("entity.ThaumicHorizons.Endersteed.name");
+    }
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag()) {
+            return super.func_145748_c_();
+        } else {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.Endersteed.name");
+        }
     }
 
     protected boolean teleportTo(final double p_70825_1_, final double p_70825_3_, final double p_70825_5_) {

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
@@ -48,7 +48,7 @@ public class EntityFamiliar extends EntityOcelot {
     public void updateAITick() {
         super.updateAITick();
         if (this.ticksExisted % 10 == 0) {
-            final List<EntityPlayer> players = (List<EntityPlayer>) this.worldObj.getEntitiesWithinAABB(
+            final List<EntityPlayer> players = this.worldObj.getEntitiesWithinAABB(
                     EntityPlayer.class,
                     AxisAlignedBB.getBoundingBox(
                             this.posX - 5.0,

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityFamiliar.java
@@ -10,6 +10,8 @@ import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
@@ -26,12 +28,23 @@ public class EntityFamiliar extends EntityOcelot {
         super(p_i1688_1_);
     }
 
+    @Override
     public String getCommandSenderName() {
         return this.hasCustomNameTag() ? this.getCustomNameTag()
                 : (this.isTamed() ? StatCollector.translateToLocal("entity.ThaumicHorizons.Familiar.name")
                         : super.getCommandSenderName());
     }
 
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag() || !this.isTamed()) {
+            return super.func_145748_c_();
+        } else {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.Familiar.name");
+        }
+    }
+
+    @Override
     public void updateAITick() {
         super.updateAITick();
         if (this.ticksExisted % 10 == 0) {

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -24,6 +24,7 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatStyle;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
@@ -247,37 +248,11 @@ public class EntityGolemTH extends EntityGolemBase {
                 if (this.ticksExisted % 10 == 0 && this.worldObj.rand.nextInt(500) == 0) {
                     final EntityPlayer player = this.worldObj.getPlayerEntityByName(this.getOwnerName());
                     switch (this.voidCount) {
-                        case 0 -> {
+                        case 0, 1, 2 -> {
                             if (player != null) {
-                                player.addChatMessage(
-                                        new ChatComponentText(
-                                                EnumChatFormatting.ITALIC + ""
-                                                        + EnumChatFormatting.DARK_PURPLE
-                                                        + StatCollector
-                                                                .translateToLocal("thaumichorizons.golemWarning1")));
-                                break;
-                            }
-                        }
-                        case 1 -> {
-                            if (player != null) {
-                                player.addChatMessage(
-                                        new ChatComponentText(
-                                                EnumChatFormatting.ITALIC + ""
-                                                        + EnumChatFormatting.DARK_PURPLE
-                                                        + StatCollector
-                                                                .translateToLocal("thaumichorizons.golemWarning2")));
-                                break;
-                            }
-                        }
-                        case 2 -> {
-                            if (player != null) {
-                                player.addChatMessage(
-                                        new ChatComponentText(
-                                                EnumChatFormatting.ITALIC + ""
-                                                        + EnumChatFormatting.DARK_PURPLE
-                                                        + StatCollector
-                                                                .translateToLocal("thaumichorizons.golemWarning3")));
-                                break;
+                                final ChatComponentTranslation message = new ChatComponentTranslation("thaumichorizons.golemWarning" + this.voidCount);
+                                message.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE).setItalic(true));
+                                player.addChatMessage(message);
                             }
                         }
                         case 3 -> {
@@ -349,21 +324,17 @@ public class EntityGolemTH extends EntityGolemBase {
     public void readEntityFromNBT(final NBTTagCompound nbt) {
         super.readEntityFromNBT(nbt);
         this.type = EnumGolemTHType.getType(nbt.getByte("GolemTypeTH"));
-        this.upgrades = new byte[this.type.upgrades + (this.advanced ? 1 : 0)];
-        final int ul = this.upgrades.length;
+
+        final int upgradeSlots = this.type.upgrades + (this.advanced ? 1 : 0);
         this.upgrades = nbt.getByteArray("upgrades");
-        if (ul != this.upgrades.length) {
-            final byte[] tt = new byte[ul];
-            for (int a = 0; a < ul; ++a) {
-                tt[a] = -1;
-            }
-            for (int a = 0; a < this.upgrades.length; ++a) {
-                if (a < ul) {
-                    tt[a] = this.upgrades[a];
-                }
+        if (upgradeSlots != this.upgrades.length) {
+            byte[] tt = Arrays.copyOf(this.upgrades, upgradeSlots);
+            if (this.upgrades.length < upgradeSlots) {
+                Arrays.fill(tt, this.upgrades.length, upgradeSlots, (byte) -1);
             }
             this.upgrades = tt;
         }
+
         StringBuilder st = new StringBuilder();
         for (final byte c : this.upgrades) {
             st.append(Integer.toHexString(c));
@@ -498,7 +469,6 @@ public class EntityGolemTH extends EntityGolemBase {
                         this.md,
                         3);
                 final SimpleNetworkWrapper instance = PacketHandler.INSTANCE;
-                final Block blocky = this.blocky;
                 instance.sendToAllAround(
                         new PacketFXBlocksplosion(
                                 Block.getIdFromBlock(this.blocky),
@@ -530,7 +500,6 @@ public class EntityGolemTH extends EntityGolemBase {
                                 this.md,
                                 3);
                         final SimpleNetworkWrapper instance2 = PacketHandler.INSTANCE;
-                        final Block blocky2 = this.blocky;
                         instance2.sendToAllAround(
                                 new PacketFXBlocksplosion(
                                         Block.getIdFromBlock(this.blocky),
@@ -564,7 +533,6 @@ public class EntityGolemTH extends EntityGolemBase {
                                 this.md,
                                 3);
                         final SimpleNetworkWrapper instance3 = PacketHandler.INSTANCE;
-                        final Block blocky3 = this.blocky;
                         instance3.sendToAllAround(
                                 new PacketFXBlocksplosion(
                                         Block.getIdFromBlock(this.blocky),
@@ -598,7 +566,6 @@ public class EntityGolemTH extends EntityGolemBase {
                                 this.md,
                                 3);
                         final SimpleNetworkWrapper instance4 = PacketHandler.INSTANCE;
-                        final Block blocky4 = this.blocky;
                         instance4.sendToAllAround(
                                 new PacketFXBlocksplosion(
                                         Block.getIdFromBlock(this.blocky),
@@ -623,7 +590,6 @@ public class EntityGolemTH extends EntityGolemBase {
     public void writeSpawnData(final ByteBuf data) {
         super.writeSpawnData(data);
         if (this.blocky != null) {
-            final Block blocky = this.blocky;
             data.writeInt(Block.getIdFromBlock(this.blocky));
         } else {
             data.writeInt(0);

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -23,8 +23,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
@@ -128,6 +130,7 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     public boolean isValidTarget(final Entity target) {
         if (!this.berserk) {
             return super.isValidTarget(target) || target instanceof EntityCreeper;
@@ -137,6 +140,7 @@ public class EntityGolemTH extends EntityGolemBase {
                 && !target.getCommandSenderName().equals(this.getCommandSenderName());
     }
 
+    @Override
     public boolean setupGolem() {
         super.setupGolem();
         if (this.getCore() == -1) {
@@ -168,6 +172,7 @@ public class EntityGolemTH extends EntityGolemBase {
         return true;
     }
 
+    @Override
     public boolean attackEntityFrom(final DamageSource ds, float par2) {
         this.paused = false;
         if (ds == DamageSource.cactus) {
@@ -192,6 +197,7 @@ public class EntityGolemTH extends EntityGolemBase {
         return super.attackEntityFrom(ds, par2);
     }
 
+    @Override
     public int getCarryLimit() {
         int base = this.type.carry;
         if (this.worldObj.isRemote) {
@@ -201,6 +207,7 @@ public class EntityGolemTH extends EntityGolemBase {
         return base;
     }
 
+    @Override
     public float getAIMoveSpeed() {
         if (this.paused || this.inactive) {
             return 0.0f;
@@ -221,6 +228,7 @@ public class EntityGolemTH extends EntityGolemBase {
         return speed;
     }
 
+    @Override
     public void onLivingUpdate() {
         super.onLivingUpdate();
         if (!this.worldObj.isRemote) {
@@ -305,16 +313,19 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     public boolean isWithinHomeDistance(final int par1, final int par2, final int par3) {
         return this.getCore() == -1 || super.isWithinHomeDistance(par1, par2, par3);
     }
 
+    @Override
     public void setFire(final int par1) {
         if (!this.type.fireResist) {
             super.setFire(par1);
         }
     }
 
+    @Override
     public void writeEntityToNBT(final NBTTagCompound nbt) {
         super.writeEntityToNBT(nbt);
         nbt.setByte("GolemTypeTH", (byte) this.type.ordinal());
@@ -334,6 +345,7 @@ public class EntityGolemTH extends EntityGolemBase {
         nbt.setBoolean("explosive", this.kaboom);
     }
 
+    @Override
     public void readEntityFromNBT(final NBTTagCompound nbt) {
         super.readEntityFromNBT(nbt);
         this.type = EnumGolemTHType.getType(nbt.getByte("GolemTypeTH"));
@@ -368,6 +380,7 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     protected void damageEntity(final DamageSource ds, final float par2) {
         if (ds.isFireDamage() && this.type.fireResist) {
             return;
@@ -375,6 +388,7 @@ public class EntityGolemTH extends EntityGolemBase {
         super.damageEntity(ds, par2);
     }
 
+    @Override
     public int getTotalArmorValue() {
         int var1 = super.getTotalArmorValue() + this.type.armor;
         if (this.decoration.contains("V")) {
@@ -605,6 +619,7 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     public void writeSpawnData(final ByteBuf data) {
         super.writeSpawnData(data);
         if (this.blocky != null) {
@@ -620,6 +635,7 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     public void readSpawnData(final ByteBuf data) {
         super.readSpawnData(data);
         this.blocky = Block.getBlockById(data.readInt());
@@ -630,18 +646,38 @@ public class EntityGolemTH extends EntityGolemBase {
         }
     }
 
+    @Override
     public String getCommandSenderName() {
         if (this.hasCustomNameTag()) {
             return this.getCustomNameTag();
         }
+
+        if (this.blocky == null || this.blocky == Blocks.air) {
+            return StatCollector.translateToLocal("entity.ThaumicHorizons.GolemTH.voidling.name");
+        }
+
+        return StatCollector.translateToLocalFormatted("entity.ThaumicHorizons.GolemTH.name", getBlockLangKey());
+    }
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag()) {
+            return super.func_145748_c_();
+        }
+
+        if (this.blocky == null || this.blocky == Blocks.air) {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.GolemTH.voidling.name");
+        }
+
+        return new ChatComponentTranslation("entity.ThaumicHorizons.GolemTH.name", getBlockLangKey());
+    }
+
+    private String getBlockLangKey() {
         final ItemStack stack = new ItemStack(this.blocky, 1, this.md);
         if (stack.getItem() != null) {
-            return stack.getDisplayName() + " Golem";
+            return stack.getUnlocalizedName();
         }
-        if (this.blocky == null || this.blocky == Blocks.air) {
-            return "Voidling Golem";
-        }
-        return this.blocky.getLocalizedName() + " Golem";
+        return this.blocky.getUnlocalizedName();
     }
 
     public EnumGolemType getGolemType() {

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -249,8 +249,10 @@ public class EntityGolemTH extends EntityGolemBase {
                     switch (this.voidCount) {
                         case 0, 1, 2 -> {
                             if (player != null) {
-                                final ChatComponentTranslation message = new ChatComponentTranslation("thaumichorizons.golemWarning" + this.voidCount);
-                                message.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE).setItalic(true));
+                                final ChatComponentTranslation message = new ChatComponentTranslation(
+                                        "thaumichorizons.golemWarning" + this.voidCount);
+                                message.setChatStyle(
+                                        new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE).setItalic(true));
                                 player.addChatMessage(message);
                             }
                         }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGolemTH.java
@@ -22,7 +22,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.ChatStyle;
 import net.minecraft.util.DamageSource;
@@ -278,7 +277,7 @@ public class EntityGolemTH extends EntityGolemBase {
             if (this.regenTimer <= 0) {
                 this.regenTimer = this.type.regenDelay;
                 if (this.decoration.contains("F")) {
-                    this.regenTimer *= (int) 0.66f;
+                    this.regenTimer = (this.regenTimer * 2) / 3;
                 }
                 if (!this.worldObj.isRemote && this.getHealth() < this.getMaxHealth()) {
                     this.worldObj.setEntityState(this, (byte) 5);
@@ -307,7 +306,6 @@ public class EntityGolemTH extends EntityGolemBase {
         nbt.setByte("GolemType", (byte) EnumGolemType.FLESH.ordinal());
         if (this.blocky != null) {
             final String s = "block";
-            final Block blocky = this.blocky;
             nbt.setInteger(s, Block.getIdFromBlock(this.blocky));
         } else {
             nbt.setInteger("block", 0);

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGravekeeper.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGravekeeper.java
@@ -17,7 +17,9 @@ import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
@@ -44,20 +46,32 @@ public class EntityGravekeeper extends EntityOcelot {
         this.targetTasks.addTask(10, new EntityAINearestAttackableTarget(this, EntityInhabitedZombie.class, 0, false));
     }
 
+    @Override
     public boolean attackEntityAsMob(final Entity p_70652_1_) {
         return (p_70652_1_ instanceof EntityLivingBase && ((EntityLivingBase) p_70652_1_).isEntityUndead())
                 || p_70652_1_.attackEntityFrom(DamageSource.causeMobDamage(this), 2.0f);
     }
 
+    @Override
     public String getCommandSenderName() {
         return this.hasCustomNameTag() ? this.getCustomNameTag()
                 : (this.isTamed() ? StatCollector.translateToLocal("entity.ThaumicHorizons.Gravekeeper.name")
                         : super.getCommandSenderName());
     }
 
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag() || !this.isTamed()) {
+            return super.func_145748_c_();
+        } else {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.Gravekeeper.name");
+        }
+    }
+
+    @Override
     public void updateAITick() {
         super.updateAITick();
-        final List<EntityLivingBase> critters = (List<EntityLivingBase>) this.worldObj.getEntitiesWithinAABB(
+        final List<EntityLivingBase> critters = this.worldObj.getEntitiesWithinAABB(
                 EntityLivingBase.class,
                 AxisAlignedBB.getBoundingBox(
                         this.posX - 5.0,
@@ -86,12 +100,14 @@ public class EntityGravekeeper extends EntityOcelot {
         }
     }
 
+    @Override
     protected void entityInit() {
         super.entityInit();
         final byte b0 = this.dataWatcher.getWatchableObjectByte(16);
         this.dataWatcher.updateObject(16, (byte) (b0 | 0x4));
     }
 
+    @Override
     public boolean isTamed() {
         return true;
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGuardianPanther.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityGuardianPanther.java
@@ -23,7 +23,9 @@ import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
@@ -49,12 +51,14 @@ public class EntityGuardianPanther extends EntityOcelot implements IEntityInfuse
         this.targetTasks.addTask(3, new EntityAIHurtByTarget(this, true));
     }
 
+    @Override
     protected void applyEntityAttributes() {
         super.applyEntityAttributes();
         this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(24.0);
         this.getEntityAttribute(SharedMonsterAttributes.movementSpeed).setBaseValue(0.5000000119209289);
     }
 
+    @Override
     public boolean interact(final EntityPlayer p_70085_1_) {
         final ItemStack itemstack = p_70085_1_.inventory.getCurrentItem();
         if (itemstack != null && itemstack.getItem() instanceof final ItemFood itemfood) {
@@ -70,30 +74,45 @@ public class EntityGuardianPanther extends EntityOcelot implements IEntityInfuse
         return super.interact(p_70085_1_);
     }
 
+    @Override
     public boolean attackEntityAsMob(final Entity p_70652_1_) {
         return p_70652_1_.attackEntityFrom(DamageSource.causeMobDamage(this), 6.0f);
     }
 
+    @Override
     public String getCommandSenderName() {
         return this.hasCustomNameTag() ? this.getCustomNameTag()
                 : (this.isTamed() ? StatCollector.translateToLocal("entity.ThaumicHorizons.GuardianPanther.name")
                         : super.getCommandSenderName());
     }
 
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag() || !this.isTamed()) {
+            return super.func_145748_c_();
+        } else {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.GuardianPanther.name");
+        }
+    }
+
+    @Override
     public void updateAITick() {
         super.updateAITick();
     }
 
+    @Override
     protected void entityInit() {
         super.entityInit();
         final byte b0 = this.dataWatcher.getWatchableObjectByte(16);
         this.dataWatcher.updateObject(16, (byte) (b0 | 0x4));
     }
 
+    @Override
     public boolean isTamed() {
         return true;
     }
 
+    @Override
     public void resetStats() {
         this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(24.0);
         this.getEntityAttribute(SharedMonsterAttributes.movementSpeed).setBaseValue(0.5000000119209289);

--- a/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNightmare.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/entities/EntityNightmare.java
@@ -12,6 +12,8 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -126,6 +128,16 @@ public class EntityNightmare extends EntityEndersteed {
         return StatCollector.translateToLocal("entity.ThaumicHorizons.NightmareTH.name");
     }
 
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag()) {
+            return super.func_145748_c_();
+        } else {
+            return new ChatComponentTranslation("entity.ThaumicHorizons.NightmareTH.name");
+        }
+    }
+
+    @Override
     public void onUpdate() {
         final AxisAlignedBB axisalignedbb = AxisAlignedBB.getBoundingBox(
                 this.boundingBox.minX,
@@ -177,6 +189,7 @@ public class EntityNightmare extends EntityEndersteed {
         }
     }
 
+    @Override
     public void setInWeb() {
         this.isInWeb = false;
         this.fallDistance = 0.0f;

--- a/src/main/resources/assets/thaumichorizons/lang/en_US.lang
+++ b/src/main/resources/assets/thaumichorizons/lang/en_US.lang
@@ -87,6 +87,8 @@ entity.ThaumicHorizons.VoltSlime.name=Volt Slime
 entity.ThaumicHorizons.MedSlime.name=Medslime
 entity.ThaumicHorizons.Sheeder.name=Sheeder
 entity.ThaumicHorizons.LostSoul.name=Lost Soul
+entity.ThaumicHorizons.GolemTH.name=%s Golem
+entity.ThaumicHorizons.GolemTH.voidling.name=Voidling Golem
 
 ###POTIONS###
 


### PR DESCRIPTION
Implements `func_145748_c_` for these mobs so their names display correctly in death messages and (eventually) command outputs.

Also localizes the Golem's name, cleans up some minor issues, adds in `@Override` where applicable, fixes an infinite regen bug, and improves localization.

(TODO: Test changes)