### PR TITLE
Display Warded Syringe with correct NBT data in NEI

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeEmpty.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeEmpty.java
@@ -4,6 +4,8 @@
 
 package com.kentington.thaumichorizons.common.items;
 
+import java.util.List;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
@@ -19,8 +21,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 

--- a/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeEmpty.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/items/ItemSyringeEmpty.java
@@ -5,6 +5,7 @@
 package com.kentington.thaumichorizons.common.items;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
@@ -18,6 +19,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+
+import java.util.List;
 
 import com.kentington.thaumichorizons.common.ThaumicHorizons;
 
@@ -41,6 +44,11 @@ public class ItemSyringeEmpty extends Item {
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(final int par1) {
         return this.icon;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void getSubItems(final Item par1, final CreativeTabs par2CreativeTabs, final List par3List) {
+        par3List.add(new ItemStack(this, 1, 2));
     }
 
     public String getUnlocalizedName(final ItemStack par1ItemStack) {


### PR DESCRIPTION
## Summary
Changes the Warded Syringe to have damage=2 when displayed in NEI, so that its recipe is correctly found.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26104

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
