### PR TITLE
Fix Ethereal Shard ClassCastException upon being jared

### DIFF
--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
@@ -83,24 +83,24 @@ public class BlockSyntheticNode extends BlockContainer {
         return false;
     }
 
-    public void breakBlock(final World p_149749_1_, final int p_149749_2_, final int p_149749_3_, final int p_149749_4_,
-            final Block p_149749_5_, final int p_149749_6_) {
-        if (p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_) instanceof TileJarNode) {
-            super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+    public void breakBlock(final World world, final int x, final int y, final int z,
+            final Block block, final int meta) {
+        if (world.getTileEntity(x, y, z) instanceof TileJarNode) {
+            super.breakBlock(world, x, y, z, block, meta);
             return;
         }
-        final TileSyntheticNode tile = (TileSyntheticNode) p_149749_1_
-                .getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
+        final TileSyntheticNode tile = (TileSyntheticNode) world
+                .getTileEntity(x, y, z);
         if (tile != null) {
             for (final Aspect asp : tile.getMaxAspects().getAspects()) {
                 final ItemStack essence = new ItemStack(
                         ConfigItems.itemWispEssence,
                         tile.getMaxAspects().getAmount(asp) / 4);
                 ((ItemWispEssence) ConfigItems.itemWispEssence).setAspects(essence, new AspectList().add(asp, 2));
-                p_149749_1_.spawnEntityInWorld(
-                        new EntityItem(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, essence));
+                world.spawnEntityInWorld(
+                        new EntityItem(world, x, y, z, essence));
             }
         }
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+        super.breakBlock(world, x, y, z, block, meta);
     }
 }

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
@@ -24,7 +24,6 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.ItemWispEssence;
-import thaumcraft.common.tiles.TileJarNode;
 
 public class BlockSyntheticNode extends BlockContainer {
 
@@ -83,23 +82,18 @@ public class BlockSyntheticNode extends BlockContainer {
         return false;
     }
 
-    public void breakBlock(final World world, final int x, final int y, final int z,
-            final Block block, final int meta) {
-        if (world.getTileEntity(x, y, z) instanceof TileJarNode) {
+    public void breakBlock(final World world, final int x, final int y, final int z, final Block block,
+            final int meta) {
+        if (!(world.getTileEntity(x, y, z) instanceof TileSyntheticNode tile)) {
             super.breakBlock(world, x, y, z, block, meta);
             return;
         }
-        final TileSyntheticNode tile = (TileSyntheticNode) world
-                .getTileEntity(x, y, z);
-        if (tile != null) {
-            for (final Aspect asp : tile.getMaxAspects().getAspects()) {
-                final ItemStack essence = new ItemStack(
-                        ConfigItems.itemWispEssence,
-                        tile.getMaxAspects().getAmount(asp) / 4);
-                ((ItemWispEssence) ConfigItems.itemWispEssence).setAspects(essence, new AspectList().add(asp, 2));
-                world.spawnEntityInWorld(
-                        new EntityItem(world, x, y, z, essence));
-            }
+        for (final Aspect asp : tile.getMaxAspects().getAspects()) {
+            final ItemStack essence = new ItemStack(
+                    ConfigItems.itemWispEssence,
+                    tile.getMaxAspects().getAmount(asp) / 4);
+            ((ItemWispEssence) ConfigItems.itemWispEssence).setAspects(essence, new AspectList().add(asp, 2));
+            world.spawnEntityInWorld(new EntityItem(world, x, y, z, essence));
         }
         super.breakBlock(world, x, y, z, block, meta);
     }

--- a/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
+++ b/src/main/java/com/kentington/thaumichorizons/common/blocks/BlockSyntheticNode.java
@@ -24,6 +24,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.items.ItemWispEssence;
+import thaumcraft.common.tiles.TileJarNode;
 
 public class BlockSyntheticNode extends BlockContainer {
 
@@ -84,6 +85,10 @@ public class BlockSyntheticNode extends BlockContainer {
 
     public void breakBlock(final World p_149749_1_, final int p_149749_2_, final int p_149749_3_, final int p_149749_4_,
             final Block p_149749_5_, final int p_149749_6_) {
+        if (p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_) instanceof TileJarNode) {
+            super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+            return;
+        }
         final TileSyntheticNode tile = (TileSyntheticNode) p_149749_1_
                 .getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
         if (tile != null) {


### PR DESCRIPTION
## Summary
This PR fixes the ClassCastException that happens when an Ethereal Shard is jared by returning early. This felt awful to write but I couldn't come up with anything better.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26513

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
